### PR TITLE
switch from JUnit to GoogleTest result type

### DIFF
--- a/job_templates/ros2_batch_ci_job.xml.template
+++ b/job_templates/ros2_batch_ci_job.xml.template
@@ -98,13 +98,13 @@ use_whitespace: ${{build.buildVariableResolver.resolve('CI_USE_WHITESPACE_IN_PAT
   <publishers>{extra_publishers}
     <xunit plugin="xunit@1.96">
       <types>
-        <JUnitType>
+        <GoogleTestType>
           <pattern>workspace/build/*/test_results/**/*.xml</pattern>
           <skipNoTestFiles>false</skipNoTestFiles>
           <failIfNotNew>true</failIfNotNew>
           <deleteOutputFiles>true</deleteOutputFiles>
           <stopProcessingIfError>true</stopProcessingIfError>
-        </JUnitType>
+         </GoogleTestType>
       </types>
       <thresholds>
         <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>


### PR DESCRIPTION
Currently we use XUnit with the JUnit result type which is unable to parse the result files generated by GTest:

    http://ci.ros2.org/job/ros2_batch_ci_osx/56/

I changed the OS X job to use XUnit with the GoogleTest result type which seems to work:

    http://ci.ros2.org/job/ros2_batch_ci_osx/57/