### PR TITLE
use x86_amd64 instead of amd64 on windows

### DIFF
--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -62,7 +62,7 @@ class WindowsBatchJob(BatchJob):
             f.write(
                 'call '
                 '"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat" '
-                'amd64' + os.linesep)
+                'x86_amd64' + os.linesep)
             if connext_env_file is not None:
                 f.write('call "%s"%s' % (connext_env_file, os.linesep))
             if opensplice_env_file is not None:


### PR DESCRIPTION
We are going to use the Community edition of Visual Studio 2015 now. That requires a different compiler.

Connects to ros2/ros2#72