### PR TITLE
use Connext 5.2 pro

### DIFF
--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -39,8 +39,9 @@ class WindowsBatchJob(BatchJob):
         # Try to find the connext env file and source it
         connext_env_file = None
         if self.args.connext:
-            pf_x86 = os.environ.get('ProgramFiles(x86)', "C:\\Program Files (x86)\\")
-            connext_env_file = os.path.join(pf_x86, 'RTI', 'rti_set_env_5.1.0.bat')
+            pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
+            connext_env_file = os.path.join(
+                pf, 'rti_connext_dds-5.2.0', 'resource', 'scripts', 'rtisetenv_X64Win64VS2013.bat')
             if not os.path.exists(connext_env_file):
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
                     connext_env_file))


### PR DESCRIPTION
Use RTI Connext 5.2 Professional on the windows slave.

Together with ros2/rmw_connext#75: ~~http://ci.ros2.org/job/ros2_batch_ci_windows/164/~~ http://ci.ros2.org/job/ros2_batch_ci_windows/187/