### PR TITLE
set different domain ids for each os

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -28,6 +28,8 @@ RUN pip3 install -U setuptools pip virtualenv
 
 # Install the OpenSplice binary from the OSRF repositories.
 RUN apt-get update && apt-get install -y libopensplice64
+# Update default domain id
+RUN sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml
 
 # Install the RTI dependencies
 RUN apt-get update && apt-get install -y default-jre-headless

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -26,7 +26,7 @@ class LinuxBatchJob(BatchJob):
         BatchJob.__init__(self)
 
     def pre(self):
-        pass
+        os.environ['ROS_DOMAIN_ID'] = '108'
 
     def show_env(self):
         # Show the env

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -28,6 +28,7 @@ class OSXBatchJob(BatchJob):
     def pre(self):
         # Prepend the PATH with `/usr/local/bin` for global Homebrew binaries.
         os.environ['PATH'] = "/usr/local/bin" + os.pathsep + os.environ.get('PATH', '')
+        os.environ['ROS_DOMAIN_ID'] = '111'
 
     def show_env(self):
         # Show the env

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -27,7 +27,7 @@ class WindowsBatchJob(BatchJob):
         BatchJob.__init__(self)
 
     def pre(self):
-        pass
+        os.environ['ROS_DOMAIN_ID'] = '119'
 
     def show_env(self):
         # Show the env


### PR DESCRIPTION
To prevent any kind of cross talk this patch adds different ROS_DOMAIN_IDs for each platform.

When this is merged the OpenSplice config files on the OS X and Windows slaves must be updated.

http://ci.ros2.org/job/ros2_batch_ci_linux/241/