### PR TITLE
Update job to build the bridge on OSX.

### DIFF
--- a/job_templates/ros2_packaging_job.xml.template
+++ b/job_templates/ros2_packaging_job.xml.template
@@ -93,15 +93,16 @@ fi
 if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
   export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
 fi
-export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/indigo"
 
 rm -rf workspace
 
 @[if os_name == 'linux']@
+export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/indigo"
 docker build -t ros2_packaging linux_packaging_docker_resources
 echo "Using args: $CI_ARGS"
 docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -i -v `pwd`:/home/rosbuild/ci_scripts ros2_packaging
 @[else]@
+export CI_ARGS="$CI_ARGS --ros1-path /Users/osrf/indigo/install_isolated"
 echo "Using args: $CI_ARGS"
 /usr/local/bin/python3 -u run_ros2_packaging.py $CI_ARGS
 @[end if]@

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -55,7 +55,7 @@ def build_and_package(args, job):
 
     # It only makes sense to build the bridge for Linux or OSX, since
     # ROS1 is not supported on Windows
-    if args.os == 'linux':
+    if args.os in ['linux', 'osx']:
         # Now run ament build only for the bridge
         job.run([
             job.python, '-u', ament_py, 'build',


### PR DESCRIPTION
We're assuming a pre-existing installation of indigo specifically located
at /Users/osrf/indigo/install_isolated.  Furthermore, that installation
must have been patched to comment out the import of roslz4 in
rosbag/bag.py.