### PR TITLE
fix CI jobs when having spaces in the paths

### DIFF
--- a/job_templates/ros2_batch_ci_job.xml.template
+++ b/job_templates/ros2_batch_ci_job.xml.template
@@ -171,13 +171,15 @@ python -u run_ros2_batch.py %CI_ARGS%
     </hudson.plugins.warnings.WarningsPublisher>
     <xunit plugin="xunit@@1.96">
       <types>
+@[for prefix in ['workspace/build', 'work space/build space']]@
         <GoogleTestType>
-          <pattern>workspace/build/*/test_results/**/*.xml</pattern>
-          <skipNoTestFiles>false</skipNoTestFiles>
+          <pattern>@(prefix)/*/test_results/**/*.xml</pattern>
+          <skipNoTestFiles>true</skipNoTestFiles>
           <failIfNotNew>true</failIfNotNew>
           <deleteOutputFiles>true</deleteOutputFiles>
           <stopProcessingIfError>true</stopProcessingIfError>
         </GoogleTestType>
+@[end for]@
       </types>
       <thresholds>
         <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>

--- a/job_templates/ros2_batch_ci_job.xml.template
+++ b/job_templates/ros2_batch_ci_job.xml.template
@@ -172,13 +172,27 @@ python -u run_ros2_batch.py %CI_ARGS%
     <xunit plugin="xunit@@1.96">
       <types>
 @[for prefix in ['workspace/build', 'work space/build space']]@
+        <CTestType>
+          <pattern>@(prefix)/*/Testing/*/Test.xml</pattern>
+          <skipNoTestFiles>true</skipNoTestFiles>
+          <failIfNotNew>true</failIfNotNew>
+          <deleteOutputFiles>true</deleteOutputFiles>
+          <stopProcessingIfError>true</stopProcessingIfError>
+        </CTestType>
         <GoogleTestType>
-          <pattern>@(prefix)/*/test_results/**/*.xml</pattern>
+          <pattern>@(prefix)/*/test_results/**/*.gtest.xml</pattern>
           <skipNoTestFiles>true</skipNoTestFiles>
           <failIfNotNew>true</failIfNotNew>
           <deleteOutputFiles>true</deleteOutputFiles>
           <stopProcessingIfError>true</stopProcessingIfError>
         </GoogleTestType>
+        <JUnitType>
+          <pattern>@(prefix)/*/test_results/**/*.xunit.xml</pattern>
+          <skipNoTestFiles>true</skipNoTestFiles>
+          <failIfNotNew>true</failIfNotNew>
+          <deleteOutputFiles>true</deleteOutputFiles>
+          <stopProcessingIfError>true</stopProcessingIfError>
+        </JUnitType>
 @[end for]@
       </types>
       <thresholds>

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -32,7 +32,7 @@ class LinuxBatchJob(BatchJob):
         # Show the env
         self.run(['export'], shell=True)
         # Show what pip has
-        self.run([self.python, '-m', 'pip', 'freeze'])
+        self.run(['"%s"' % self.python, '-m', 'pip', 'freeze'], shell=True)
 
     def setup_env(self):
         connext_env_file = None

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -36,7 +36,7 @@ class OSXBatchJob(BatchJob):
         # Show what brew has
         self.run(['brew', 'list'])
         # Show what pip has
-        self.run([self.python, '-m', 'pip', 'freeze'])
+        self.run(['"%s"' % self.python, '-m', 'pip', 'freeze'], shell=True)
 
     def setup_env(self):
         connext_env_file = None


### PR DESCRIPTION
Before using spaces failed very early on all platforms.

Now it passes on Windows:
* http://ci.ros2.org/job/ros2_batch_ci_windows/339/

And runs until the OpenSplice issue on Linux and OS X again:
* http://ci.ros2.org/job/ros2_batch_ci_linux/315/
* http://ci.ros2.org/job/ros2_batch_ci_osx/245/

"Normal" builds without spaces continue to work:
* http://ci.ros2.org/job/ros2_batch_ci_linux/314/
* http://ci.ros2.org/job/ros2_batch_ci_osx/244/
* http://ci.ros2.org/job/ros2_batch_ci_windows/338/