### PR TITLE
install boost for eProsima

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -42,6 +42,9 @@ ADD rticonnextdds-src/librticonnextdds52_5.2.0-1_amd64.deb /tmp/librticonnextdds
 ADD rticonnextdds-src/librticonnextdds52-dev_5.2.0-1_amd64.deb /tmp/librticonnextdds52-dev_5.2.0-1_amd64.deb
 ADD rticonnextdds-src/rticonnextdds-tools_5.2.0-1_amd64.deb /tmp/rticonnextdds-tools_5.2.0-1_amd64.deb
 
+# Install the eProsima dependencies
+RUN apt-get update && apt-get install -y libboost-chrono-dev libboost-date-time-dev libboost-regex-dev libboost-system-dev libboost-thread-dev
+
 # Install OpenCV
 RUN apt-get update && apt-get install -y libopencv-dev
 


### PR DESCRIPTION
This is necessary if we want to build the eProsima packages.

Connect to ros2/ros2#124