### PR TITLE
skipped tests should not affect the build status

### DIFF
--- a/job_templates/ros2_batch_ci_job.xml.template
+++ b/job_templates/ros2_batch_ci_job.xml.template
@@ -203,7 +203,7 @@ python -u run_ros2_batch.py %CI_ARGS%
           <failureNewThreshold></failureNewThreshold>
         </org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
         <org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
-          <unstableThreshold>0</unstableThreshold>
+          <unstableThreshold></unstableThreshold>
           <unstableNewThreshold></unstableNewThreshold>
           <failureThreshold></failureThreshold>
           <failureNewThreshold></failureNewThreshold>


### PR DESCRIPTION
Since skipped tests are intentional (e.g. on Windows: http://ci.ros2.org/job/ros2_batch_ci_windows/419/) they should not affect the build status.