### PR TITLE
set LANG

### DIFF
--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -28,6 +28,8 @@ class OSXBatchJob(BatchJob):
     def pre(self):
         # Prepend the PATH with `/usr/local/bin` for global Homebrew binaries.
         os.environ['PATH'] = "/usr/local/bin" + os.pathsep + os.environ.get('PATH', '')
+        if 'LANG' not in os.environ:
+            os.environ['LANG'] = 'en_US.UTF-8'
         os.environ['ROS_DOMAIN_ID'] = '111'
 
     def show_env(self):


### PR DESCRIPTION
When building FastRTPS which contains non-ascii characters in the package manifest files it fails without this patch: http://ci.ros2.org/job/ros2_batch_ci_osx/290/

With the patch it passes that point: http://ci.ros2.org/job/ros2_batch_ci_osx/291/