### PR TITLE
add optional ament args to job parameters

### DIFF
--- a/job_templates/ros2_batch_ci_job.xml.template
+++ b/job_templates/ros2_batch_ci_job.xml.template
@@ -64,7 +64,8 @@ connext: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT')}, <br/>
 ci_branch: ${build.buildVariableResolver.resolve('CI_SCRIPTS_BRANCH')}, <br/>
 repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_REPOS_URL')}, <br/>
 use_whitespace: ${build.buildVariableResolver.resolve('CI_USE_WHITESPACE_IN_PATHS')}, <br/>
-isolated: ${build.buildVariableResolver.resolve('CI_ISOLATED')}\
+isolated: ${build.buildVariableResolver.resolve('CI_ISOLATED')}, <br/>
+ament_args: ${build.buildVariableResolver.resolve('CI_AMENT_ARGS')}\
 """);]]>
         </command>
       </scriptSource>
@@ -89,6 +90,9 @@ if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
 fi
 if [ "$CI_ISOLATED" = "true" ]; then
   export CI_ARGS="$CI_ARGS --isolated"
+fi
+if [ -n "${CI_AMENT_ARGS+x}" ]; then
+  export CI_ARGS="$CI_ARGS --ament-args $CI_AMENT_ARGS"
 fi
 
 rm -rf workspace "work space"
@@ -118,6 +122,9 @@ if "%CI_ROS2_REPOS_URL%" NEQ "" (
 )
 if "%CI_ISOLATED%" == "true" (
   set "CI_ARGS=%CI_ARGS% --isolated"
+)
+if "%CI_AMENT_ARGS%" NEQ "" (
+  set "CI_ARGS=%CI_ARGS% --ament-args %CI_AMENT_ARGS%"
 )
 
 rmdir /S /Q workspace "work space"

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -38,5 +38,10 @@ This is always in addition to OpenSplice.</description>
           <description>By setting this to True, the build will use the --isolated option.</description>
           <defaultValue>false</defaultValue>
         </hudson.model.BooleanParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CI_AMENT_ARGS</name>
+          <description>Additional arguments passed to ament.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>


### PR DESCRIPTION
Add parameter for ament arguments to Jenkins jobs. It will e.g.:
* enable to select only specific tests (`-R test_services_cpp__rmw_opensplice_cpp`)
* run tests repeatedly (`--repeat-until-fail 100`) (if the CMake version used supports it)

http://ci.ros2.org/job/ros2_batch_ci_osx/328/