### PR TITLE
make isolated builds the default option

### DIFF
--- a/job_templates/ros2_batch_ci_launcher_job.xml.template
+++ b/job_templates/ros2_batch_ci_launcher_job.xml.template
@@ -6,6 +6,7 @@
   <properties>
 @(SNIPPET(
     'property_parameter-definition',
+    ament_args_default='',
 ))@
     <org.jenkinsci.plugins.requeuejob.RequeueJobProperty plugin="jobrequeue@@1.0">
       <requeueJob>true</requeueJob>

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -36,7 +36,7 @@ This is always in addition to OpenSplice.</description>
         <hudson.model.BooleanParameterDefinition>
           <name>CI_ISOLATED</name>
           <description>By setting this to True, the build will use the --isolated option.</description>
-          <defaultValue>false</defaultValue>
+          <defaultValue>true</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_AMENT_ARGS</name>


### PR DESCRIPTION
Being stricter in the CI jobs will prevent us from regressions like ros2/rmw_connext#105 in the future.