### PR TITLE
adding class_loader and dependencies to repos file

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -43,6 +43,10 @@ repositories:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
     version: master
+  ros/class_loader:
+    type: git
+    url: https://github.com/ros/class_loader.git
+    version: ros2
   ros/geometry2:
     type: git
     url: https://github.com/ros/geometry2.git
@@ -62,6 +66,10 @@ repositories:
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
+    version: master
+  ros/poco_vendor:
+    type: git
+    url: https://github.com/ros2/poco_vendor.git
     version: master
   ros2/rcl:
     type: git


### PR DESCRIPTION
This adds class_loader, console_bridge, and poco_vendor to the default set of packages for CI and from source builds.
