### PR TITLE
change default behavior for Windows jobs to reflect no multi vendor building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ docs/_build/
 # PyBuilder
 target/
 workspace
+ws
 .DS_Store
 work space

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -66,6 +66,10 @@ def main(argv=None):
         'ci_scripts_default_branch': args.ci_scripts_default_branch,
         'time_trigger_spec': '',
         'mailer_recipients': '',
+        'use_connext_default': 'true',
+        'disable_connext_static_default': 'false',
+        'disable_connext_dynamic_default': 'false',
+        'use_opensplice_default': 'true',
         'ament_args_default': '',
     }
 
@@ -86,6 +90,26 @@ def main(argv=None):
         'windows': {
             'label_expression': 'windows_slave_eatable',
             'shell_type': 'BatchFile',
+            'use_connext_default': 'false',
+            'disable_connext_static_default': 'false',
+            'disable_connext_dynamic_default': 'false',
+            'use_opensplice_default': 'true',
+        },
+        'windows_connext_static': {
+            'label_expression': 'windows_slave_eatable',
+            'shell_type': 'BatchFile',
+            'use_connext_default': 'true',
+            'disable_connext_static_default': 'false',
+            'disable_connext_dynamic_default': 'true',
+            'use_opensplice_default': 'false',
+        },
+        'windows_connext_dynamic': {
+            'label_expression': 'windows_slave_eatable',
+            'shell_type': 'BatchFile',
+            'use_connext_default': 'true',
+            'disable_connext_static_default': 'true',
+            'disable_connext_dynamic_default': 'false',
+            'use_opensplice_default': 'false',
         },
     }
 
@@ -98,7 +122,7 @@ def main(argv=None):
         # configure manual triggered job
         job_name = 'ros2_batch_ci_' + os_name
         job_data = dict(data)
-        job_data['os_name'] = os_name
+        job_data['os_name'] = 'windows' if os_name.startswith('windows') else os_name
         job_data.update(os_configs[os_name])
         job_config = expand_template('ros2_batch_ci_job.xml.template', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -87,7 +87,7 @@ def main(argv=None):
             'ci_scripts_repository': args.ci_scripts_repository.replace(
                 'git@github.com:', 'https://github.com/'),
         },
-        'windows': {
+        'windows_opensplice': {
             'label_expression': 'windows_slave_eatable',
             'shell_type': 'BatchFile',
             'use_connext_default': 'false',
@@ -141,7 +141,15 @@ def main(argv=None):
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
     # configure the launch job
-    job_data = {'label_expression': 'master'}
+    os_specific_data = {}
+    for os_name, os_data in os_configs.items():
+        os_specific_data[os_name] = dict(data)
+        os_specific_data[os_name].update(os_configs[os_name])
+        os_specific_data[os_name]['job_name'] = 'ros2_batch_ci_' + os_name
+    job_data = {
+        'label_expression': 'master',
+        'os_specific_data': os_specific_data,
+    }
     job_config = expand_template('ros2_batch_ci_launcher_job.xml.template', job_data)
     configure_job(jenkins, 'ros2_batch_ci_launcher', job_config, **jenkins_kwargs)
 

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import collections
 import os
 import sys
 
@@ -43,7 +44,7 @@ template_prefix_path[:] = \
 def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
-    parser = argparse.ArgumentParser(description="Creates the 'ros2_batch_ci_osx' job on Jenkins")
+    parser = argparse.ArgumentParser(description="Creates the ros2 jobs on Jenkins")
     parser.add_argument(
         '--jenkins-url', '-u', default='http://ci.ros2.org',
         help="Url of the jenkins server to which the job should be added")
@@ -120,38 +121,40 @@ def main(argv=None):
     # configure os specific jobs
     for os_name in sorted(os_configs.keys()):
         # configure manual triggered job
-        job_name = 'ros2_batch_ci_' + os_name
+        job_name = 'ci_' + os_name
         job_data = dict(data)
         job_data['os_name'] = 'windows' if os_name.startswith('windows') else os_name
         job_data.update(os_configs[os_name])
-        job_config = expand_template('ros2_batch_ci_job.xml.template', job_data)
+        job_config = expand_template('ci_job.xml.template', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
-        # configure packaging job
-        job_name = 'ros2_packaging_' + os_name
-        job_config = expand_template('ros2_packaging_job.xml.template', job_data)
-        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+        # configure packaging job (skip non-opensplice Windows packaging jobs)
+        if not os_name.startswith('windows') or 'opensplice' in os_name:
+            job_name = 'packaging_' + os_name
+            job_config = expand_template('packaging_job.xml.template', job_data)
+            configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
         # configure nightly triggered job
-        job_name = 'ros2_batch_ci_' + os_name + '_nightly'
+        job_name = 'nightly_' + os_name
         job_data['time_trigger_spec'] = '0 11 * * *'
         job_data['mailer_recipients'] = 'ros@osrfoundation.org'
         job_data['ament_args_default'] = '--ctest-args --repeat-until-fail 20'
-        job_config = expand_template('ros2_batch_ci_job.xml.template', job_data)
+        job_config = expand_template('ci_job.xml.template', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
     # configure the launch job
-    os_specific_data = {}
-    for os_name, os_data in os_configs.items():
+    os_specific_data = collections.OrderedDict()
+    for os_name in sorted(os_configs.keys()):
+        os_data = os_configs[os_name]
         os_specific_data[os_name] = dict(data)
         os_specific_data[os_name].update(os_configs[os_name])
-        os_specific_data[os_name]['job_name'] = 'ros2_batch_ci_' + os_name
+        os_specific_data[os_name]['job_name'] = 'ci_' + os_name
     job_data = {
         'label_expression': 'master',
         'os_specific_data': os_specific_data,
     }
-    job_config = expand_template('ros2_batch_ci_launcher_job.xml.template', job_data)
-    configure_job(jenkins, 'ros2_batch_ci_launcher', job_config, **jenkins_kwargs)
+    job_config = expand_template('ci_launcher_job.xml.template', job_data)
+    configure_job(jenkins, 'ci_launcher', job_config, **jenkins_kwargs)
 
 
 if __name__ == '__main__':

--- a/job_templates/ci_job.xml.template
+++ b/job_templates/ci_job.xml.template
@@ -4,7 +4,7 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.12.1">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.14.0">
       <projectUrl>@(ci_scripts_repository)/</projectUrl>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
 @(SNIPPET(
@@ -112,7 +112,7 @@ if [ -n "${CI_AMENT_ARGS+x}" ]; then
   export CI_ARGS="$CI_ARGS --ament-args $CI_AMENT_ARGS"
 fi
 
-rm -rf workspace "work space"
+rm -rf ws workspace "work space"
 
 @[if os_name == 'linux']@
 docker build -t ros2_batch_ci linux_docker_resources
@@ -153,7 +153,7 @@ if "%CI_AMENT_ARGS%" NEQ "" (
   set "CI_ARGS=%CI_ARGS% --ament-args %CI_AMENT_ARGS%"
 )
 
-rmdir /S /Q workspace "work space"
+rmdir /S /Q ws workspace "work space"
 
 echo Using args: %CI_ARGS%
 python -u run_ros2_batch.py %CI_ARGS%
@@ -168,7 +168,7 @@ python -u run_ros2_batch.py %CI_ARGS%
     os_name=os_name,
 ))@
     <hudson.plugins.cobertura.CoberturaPublisher plugin="cobertura@@1.9.7">
-      <coberturaReportFile>workspace/build*/*/coverage.xml</coberturaReportFile>
+      <coberturaReportFile>ws/build*/*/coverage.xml</coberturaReportFile>
       <onlyStable>false</onlyStable>
       <failUnhealthy>false</failUnhealthy>
       <failUnstable>false</failUnstable>
@@ -227,9 +227,9 @@ python -u run_ros2_batch.py %CI_ARGS%
       </failingTarget>
       <sourceEncoding>ASCII</sourceEncoding>
     </hudson.plugins.cobertura.CoberturaPublisher>
-    <xunit plugin="xunit@@1.96">
+    <xunit plugin="xunit@@1.98">
       <types>
-@[for prefix in ['workspace/build', 'work space/build space']]@
+@[for prefix in ['ws/build', 'work space/build space']]@
         <CTestType>
           <pattern>@(prefix)/*/Testing/*/Test.xml</pattern>
           <skipNoTestFiles>true</skipNoTestFiles>
@@ -273,7 +273,7 @@ python -u run_ros2_batch.py %CI_ARGS%
       </extraConfiguration>
     </xunit>
 @[if mailer_recipients]@
-    <hudson.tasks.Mailer plugin="mailer@@1.15">
+    <hudson.tasks.Mailer plugin="mailer@@1.16">
       <recipients>@(mailer_recipients)</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>false</sendToIndividuals>
@@ -281,8 +281,8 @@ python -u run_ros2_batch.py %CI_ARGS%
 @[end if]@
   </publishers>
   <buildWrappers>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.7.1" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.4.1">
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.7.2" />
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.4.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
 @[if os_name != 'windows']@

--- a/job_templates/ci_launcher_job.xml.template
+++ b/job_templates/ci_launcher_job.xml.template
@@ -29,7 +29,7 @@
   <builders/>
   <publishers>
 @[for os_name, os_data in os_specific_data.items()]@
-    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@@2.28">
+    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@@2.29">
       <configs>
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>

--- a/job_templates/packaging_job.xml.template
+++ b/job_templates/packaging_job.xml.template
@@ -4,7 +4,7 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.12.1">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.14.0">
       <projectUrl>@(ci_scripts_repository)/</projectUrl>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <hudson.model.ParametersDefinitionProperty>
@@ -95,7 +95,7 @@ if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
   export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
 fi
 
-rm -rf workspace
+rm -rf ws workspace
 
 @[if os_name == 'linux']@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/indigo"
@@ -118,7 +118,7 @@ if "%CI_ROS2_REPOS_URL%" NEQ "" (
   set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
 )
 
-rmdir /S /Q workspace "work space"
+rmdir /S /Q ws workspace
 
 echo Using args: %CI_ARGS%
 python -u run_ros2_packaging.py %CI_ARGS%
@@ -133,7 +133,7 @@ python -u run_ros2_packaging.py %CI_ARGS%
     os_name=os_name,
 ))@
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>workspace/ros2-package-*.*</artifacts>
+      <artifacts>ws/ros2-package-*.*</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>true</onlyIfSuccessful>
       <fingerprint>false</fingerprint>
@@ -141,8 +141,8 @@ python -u run_ros2_packaging.py %CI_ARGS%
     </hudson.tasks.ArtifactArchiver>
   </publishers>
   <buildWrappers>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.7.1" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.4.1">
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.7.2" />
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.4.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
 @[if os_name != 'windows']@

--- a/job_templates/ros2_batch_ci_job.xml.template
+++ b/job_templates/ros2_batch_ci_job.xml.template
@@ -9,6 +9,10 @@
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
 @(SNIPPET(
     'property_parameter-definition',
+    use_connext_default=use_connext_default,
+    disable_connext_static_default=disable_connext_static_default,
+    disable_connext_dynamic_default=disable_connext_dynamic_default,
+    use_opensplice_default=use_opensplice_default,
     ament_args_default=ament_args_default,
 ))@
     <org.jenkinsci.plugins.requeuejob.RequeueJobProperty plugin="jobrequeue@@1.0">

--- a/job_templates/ros2_batch_ci_launcher_job.xml.template
+++ b/job_templates/ros2_batch_ci_launcher_job.xml.template
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
   <actions/>
-  <description></description>
+  <description>
+    Note: Connext is always disabled on the Windows job, even when selected explicitly.
+  </description>
   <keepDependencies>false</keepDependencies>
   <properties>
 @(SNIPPET(
     'property_parameter-definition',
+    use_connext_default='true',
+    disable_connext_static_default='false',
+    disable_connext_dynamic_default='false',
+    use_opensplice_default='true',
     ament_args_default='',
 ))@
     <org.jenkinsci.plugins.requeuejob.RequeueJobProperty plugin="jobrequeue@@1.0">
@@ -51,6 +57,22 @@
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
+            <hudson.plugins.parameterizedtrigger.BooleanParameters>
+              <configs>
+                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                  <name>CI_USE_CONNEXT</name>
+                  <value>false</value>
+                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                  <name>CI_DISABLE_CONNEXT_STATIC</name>
+                  <value>false</value>
+                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                  <name>CI_DISABLE_CONNEXT_DYNAMIC</name>
+                  <value>false</value>
+                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+              </configs>
+            </hudson.plugins.parameterizedtrigger.BooleanParameters>
           </configs>
           <projects>ros2_batch_ci_windows</projects>
           <condition>SUCCESS</condition>

--- a/job_templates/ros2_batch_ci_launcher_job.xml.template
+++ b/job_templates/ros2_batch_ci_launcher_job.xml.template
@@ -2,7 +2,7 @@
 <project>
   <actions/>
   <description>
-    Note: Connext is always disabled on the Windows job, even when selected explicitly.
+    Note: The Windows jobs ignore the middleware selection flags.
   </description>
   <keepDependencies>false</keepDependencies>
   <properties>
@@ -28,58 +28,42 @@
   <concurrentBuild>false</concurrentBuild>
   <builders/>
   <publishers>
+@[for os_name, os_data in os_specific_data.items()]@
     <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@@2.28">
       <configs>
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
-          </configs>
-          <projects>ros2_batch_ci_linux</projects>
-          <condition>SUCCESS</condition>
-          <triggerWithNoParameters>false</triggerWithNoParameters>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-      </configs>
-    </hudson.plugins.parameterizedtrigger.BuildTrigger>
-    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@@2.28">
-      <configs>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
-          </configs>
-          <projects>ros2_batch_ci_osx</projects>
-          <condition>SUCCESS</condition>
-          <triggerWithNoParameters>false</triggerWithNoParameters>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-      </configs>
-    </hudson.plugins.parameterizedtrigger.BuildTrigger>
-    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@@2.28">
-      <configs>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
+@[if os_name.startswith('windows')]@
             <hudson.plugins.parameterizedtrigger.BooleanParameters>
               <configs>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
                   <name>CI_USE_CONNEXT</name>
-                  <value>false</value>
+                  <value>@(os_data['use_connext_default'])</value>
                 </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
                   <name>CI_DISABLE_CONNEXT_STATIC</name>
-                  <value>false</value>
+                  <value>@(os_data['disable_connext_static_default'])</value>
                 </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
                   <name>CI_DISABLE_CONNEXT_DYNAMIC</name>
-                  <value>false</value>
+                  <value>@(os_data['disable_connext_dynamic_default'])</value>
+                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                  <name>CI_USE_OPENSPLICE</name>
+                  <value>@(os_data['use_opensplice_default'])</value>
                 </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
               </configs>
             </hudson.plugins.parameterizedtrigger.BooleanParameters>
+@[end if]@
           </configs>
-          <projects>ros2_batch_ci_windows</projects>
+          <projects>@(os_data['job_name'])</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
         </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
       </configs>
     </hudson.plugins.parameterizedtrigger.BuildTrigger>
+@[end for]@
   </publishers>
   <buildWrappers/>
 </project>

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -30,22 +30,22 @@ This tests the robustness to whitespace being within the different paths.</descr
         <hudson.model.BooleanParameterDefinition>
           <name>CI_USE_CONNEXT</name>
           <description>By setting this to True, the build will attempt to use RTI&apos;s Connext.</description>
-          <defaultValue>true</defaultValue>
+          <defaultValue>@(use_connext_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>CI_DISABLE_CONNEXT_STATIC</name>
           <description>By setting this to True, the build will disable the Connext static rmw implementation.</description>
-          <defaultValue>false</defaultValue>
+          <defaultValue>@(disable_connext_static_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>CI_DISABLE_CONNEXT_DYNAMIC</name>
           <description>By setting this to True, the build will disable the Connext dynamic rmw implementation.</description>
-          <defaultValue>false</defaultValue>
+          <defaultValue>@(disable_connext_dynamic_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>CI_USE_OPENSPLICE</name>
           <description>By setting this to True, the build will attempt to use PrismTech&apos;s OpenSplice. On Linux and OS X OpenSplice is always being used despite the setting of this checkbox.</description>
-          <defaultValue>true</defaultValue>
+          <defaultValue>@(use_opensplice_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>CI_ISOLATED</name>

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.48">
+    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.50">
       <healthy/>
       <unHealthy/>
       <thresholdLimit>low</thresholdLimit>
@@ -8,7 +8,7 @@
       <usePreviousBuildAsReference>false</usePreviousBuildAsReference>
       <useStableBuildAsReference>false</useStableBuildAsReference>
       <useDeltaValues>false</useDeltaValues>
-      <thresholds plugin="analysis-core@@1.72">
+      <thresholds plugin="analysis-core@@1.74">
         <unstableTotalAll>0</unstableTotalAll>
         <unstableTotalHigh/>
         <unstableTotalNormal/>

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -163,7 +163,7 @@ def run(args, build_function):
     job = None
 
     args.white_space_in = args.white_space_in or []
-    args.workspace = 'work space' if 'workspace' in args.white_space_in else 'workspace'
+    args.workspace = 'work space' if 'workspace' in args.white_space_in else 'ws'
     args.sourcespace = 'source space' if 'sourcespace' in args.white_space_in else 'src'
     args.buildspace = 'build space' if 'buildspace' in args.white_space_in else 'build'
     args.installspace = 'install space' if 'installspace' in args.white_space_in else 'install'


### PR DESCRIPTION
Connects to ros2/ros2#150

I've already pushed the changes to the server so we can see if the nightly jobs are fixed. Here is an output of the job config diffs:

```diff
Connecting to Jenkins 'http://ci.ros2.org/'
Connected to Jenkins version '1.638'
Skipped 'ros2_batch_ci_linux' because the config is the same
Skipped 'ros2_packaging_linux' because the config is the same
Skipped 'ros2_batch_ci_linux_nightly' because the config is the same
Skipped 'ros2_batch_ci_osx' because the config is the same
Skipped 'ros2_packaging_osx' because the config is the same
Skipped 'ros2_batch_ci_osx_nightly' because the config is the same
Updating job 'ros2_batch_ci_windows'
    <<<
    --- remote config
    +++ new config
    @@ -41 +41 @@
    -          <defaultValue>true</defaultValue>
    +          <defaultValue>false</defaultValue>
    >>>
The Jenkins master does not require a crumb
Skipped 'ros2_packaging_windows' because the config is the same
Updating job 'ros2_batch_ci_windows_nightly'
    <<<
    --- remote config
    +++ new config
    @@ -41 +41 @@
    -          <defaultValue>true</defaultValue>
    +          <defaultValue>false</defaultValue>
    >>>
Creating job 'ros2_batch_ci_windows_connext_dynamic'
Creating job 'ros2_packaging_windows_connext_dynamic'
Creating job 'ros2_batch_ci_windows_connext_dynamic_nightly'
Creating job 'ros2_batch_ci_windows_connext_static'
Creating job 'ros2_packaging_windows_connext_static'
Creating job 'ros2_batch_ci_windows_connext_static_nightly'
Updating job 'ros2_batch_ci_launcher'
    <<<
    --- remote config
    +++ new config
    @@ -109,0 +110,16 @@
    +            <hudson.plugins.parameterizedtrigger.BooleanParameters>
    +              <configs>
    +                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
    +                  <name>CI_USE_CONNEXT</name>
    +                  <value>false</value>
    +                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
    +                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
    +                  <name>CI_DISABLE_CONNEXT_STATIC</name>
    +                  <value>false</value>
    +                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
    +                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
    +                  <name>CI_DISABLE_CONNEXT_DYNAMIC</name>
    +                  <value>false</value>
    +                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
    +              </configs>
    +            </hudson.plugins.parameterizedtrigger.BooleanParameters>
    >>>

```

For now I changed the launcher to only launch an opensplice job for Windows and it does so even if you select use connext by overriding those boolean job values explicitly.

Also I created two new Windows jobs, one for connext static and the other for dynamic, but left the Windows opensplice job called just `*_windows` so that the job history was preserved there.