### PR TITLE
add ccache to packaging jobs

### DIFF
--- a/job_templates/packaging_job.xml.template
+++ b/job_templates/packaging_job.xml.template
@@ -99,10 +99,11 @@ rm -rf ws workspace
 
 @[if os_name == 'linux']@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/indigo"
+mkdir -p $HOME/.ccache
 docker info
 docker build -t ros2_packaging linux_packaging_docker_resources
 echo "Using args: $CI_ARGS"
-docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -i -v `pwd`:/home/rosbuild/ci_scripts ros2_packaging
+docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache ros2_packaging
 @[else]@
 export CI_ARGS="$CI_ARGS --ros1-path /Users/osrf/indigo/install_isolated"
 echo "Using args: $CI_ARGS"

--- a/linux_packaging_docker_resources/Dockerfile
+++ b/linux_packaging_docker_resources/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` 
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | sudo apt-key add -
 
 # Install some development tools.
-RUN apt-get update && apt-get install -y build-essential cmake pkg-config python3-empy python3-setuptools python3-vcstool
+RUN apt-get update && apt-get install -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install -y clang-format-3.4 cppcheck git pyflakes python3-coverage python3-mock python3-nose python3-pep8 uncrustify

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -114,6 +114,8 @@ def get_args(sysargv=None, skip_white_space_in=False, skip_connext=False, add_ro
         args.white_space_in = None
     if skip_connext:
         args.connext = False
+        args.disable_connext_dynamic = False
+        args.disable_connext_static = False
     if not add_ros1:
         args.ros1_path = None
     return args


### PR DESCRIPTION
Not ready for review.

CI jobs:

* http://ci.ros2.org/view/packaging/job/packaging_osx/21
* http://ci.ros2.org/view/packaging/job/packaging_linux/45

We won't see any speedup on the Linux job yet (though we should see ccache being used), because it needs to be reconfigured (which we can do after this PR is merged).