### PR TITLE
use master branch of console bridge

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -126,4 +126,4 @@ repositories:
   vendor/console_bridge:
     type: git
     url: https://github.com/ros/console_bridge.git
-    version: ros2
+    version: master


### PR DESCRIPTION
The new version 0.3 should include all the changes from the `ros2` branch.

http://ci.ros2.org/job/ci_linux/842/
http://ci.ros2.org/job/ci_osx/705/
http://ci.ros2.org/job/ci_windows/910/

After this has been merged the `ros2` branch can be deleted.