### PR TITLE
use Connext VS2015

### DIFF
--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -41,7 +41,7 @@ class WindowsBatchJob(BatchJob):
         if self.args.connext:
             pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
             connext_env_file = os.path.join(
-                pf, 'rti_connext_dds-5.2.0', 'resource', 'scripts', 'rtisetenv_X64Win64VS2013.bat')
+                pf, 'rti_connext_dds-5.2.0.4', 'resource', 'scripts', 'rtisetenv_x64Win64VS2015.bat')
             if not os.path.exists(connext_env_file):
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
                     connext_env_file))


### PR DESCRIPTION
Use VS 2015 engineering build (2015-12-15) of Connext.

Only changes the exit code but fails the same tests...

Since we don't need the VS 2015 edition I will close this PR directly. I just wanted to conserve the diff necessary to use the engineering build.