### PR TITLE
Add ARM support

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -121,20 +121,28 @@ def main(argv=None):
         job_config = expand_template('packaging_job.xml.template', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
+        # keeping the paths on Windows shorter
+        os_name = os_name.replace('windows', 'win')
         # configure nightly triggered job
         job_name = 'nightly_' + os_name + '_debug'
+        if os_name == 'win':
+            job_name = job_name[0:-2]
         job_data['cmake_build_type'] = 'Debug'
         job_config = expand_template('ci_job.xml.template', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
         # configure nightly triggered job
         job_name = 'nightly_' + os_name + '_release'
+        if os_name == 'win':
+            job_name = job_name[0:-4]
         job_data['cmake_build_type'] = 'Release'
         job_config = expand_template('ci_job.xml.template', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
         # configure nightly triggered job with repeated testing
         job_name = 'nightly_' + os_name + '_repeated'
+        if os_name == 'win':
+            job_name = job_name[0:-5]
         job_data['time_trigger_spec'] = '0 12 * * *'
         job_data['cmake_build_type'] = 'None'
         job_data['ament_args_default'] = '--ctest-args --repeat-until-fail 20'

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -79,19 +79,27 @@ def main(argv=None):
 
     os_configs = {
         'linux': {
-            'label_expression': 'linux_slave_on_master',
+            'label_expression': 'linux',
             'shell_type': 'Shell',
         },
         'osx': {
-            'label_expression': 'osx_slave_dosa',
+            'label_expression': 'osx_slave',
             'shell_type': 'Shell',
             # the current OS X slave can't handle  git@github urls
             'ci_scripts_repository': args.ci_scripts_repository.replace(
                 'git@github.com:', 'https://github.com/'),
         },
         'windows': {
-            'label_expression': 'windows_slave_eatable',
+            'label_expression': 'windows_slave',
             'shell_type': 'BatchFile',
+        },
+        'linux-armhf': {
+            'label_expression': 'linux',
+            'shell_type': 'Shell',
+        },
+        'linux-aarch64': {
+            'label_expression': 'linux',
+            'shell_type': 'Shell',
         },
     }
 
@@ -110,6 +118,10 @@ def main(argv=None):
         job_data['cmake_build_type'] = 'None'
         job_config = expand_template('ci_job.xml.template', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+
+        # skip non-manual jobs on ARM for now
+        if os_name == 'linux-armhf' or os_name == 'linux-aarch64':
+            continue
 
         # all following jobs are triggered nightly with email notification
         job_data['time_trigger_spec'] = '0 11 * * *'
@@ -152,6 +164,9 @@ def main(argv=None):
     # configure the launch job
     os_specific_data = collections.OrderedDict()
     for os_name in sorted(os_configs.keys()):
+        # skip non-manual jobs on ARM for now
+        if os_name == 'linux-armhf' or os_name == 'linux-aarch64':
+            continue
         os_specific_data[os_name] = dict(data)
         os_specific_data[os_name].update(os_configs[os_name])
         os_specific_data[os_name]['job_name'] = 'ci_' + os_name

--- a/job_templates/ci_job.xml.template
+++ b/job_templates/ci_job.xml.template
@@ -67,7 +67,7 @@
     </hudson.triggers.TimerTrigger>
   @
 @[end if]</triggers>
-  <concurrentBuild>false</concurrentBuild>
+  <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@1.27">
       <scriptSource class="hudson.plugins.groovy.StringScriptSource">
@@ -92,7 +92,7 @@ ament_args: ${build.buildVariableResolver.resolve('CI_AMENT_ARGS')}\
     </hudson.plugins.groovy.SystemGroovy>
     <hudson.tasks.@(shell_type)>
       <command>@
-@[if os_name in ['linux', 'osx']]@
+@[if os_name in ['linux', 'osx', 'linux-armhf', 'linux-aarch64']]@
 rm -rf ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -133,7 +133,7 @@ fi
 echo "Using args: $CI_ARGS"
 echo "# END SECTION"
 
-@[if os_name == 'linux']@
+@[if os_name in ['linux', 'linux-armhf', 'linux-aarch64']]@
 mkdir -p $HOME/.ccache
 echo "# BEGIN SECTION: docker version"
 docker version
@@ -142,10 +142,41 @@ echo "# BEGIN SECTION: docker info"
 docker info
 echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
+@[if os_name == 'linux-armhf']@
+sed -i 's+^FROM.*$+FROM osrf/ubuntu_armhf:trusty+' linux_docker_resources/Dockerfile
+docker build --build-arg PLATFORM=arm -t ros2_batch_ci_armhf linux_docker_resources
+@[elif os_name == 'linux-aarch64']@
+sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:trusty+' linux_docker_resources/Dockerfile
+docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
+@[elif os_name == 'linux']@
 docker build -t ros2_batch_ci linux_docker_resources
+@[else]@
+@{ assert 'Unknown os_name: ' + os_name }@
+@[end if]@
 echo "# END SECTION"
 echo "# BEGIN SECTION: Run Dockerfile"
-docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache ros2_batch_ci
+export EXTRA_MOUNT=""
+@[if os_name in ['linux-armhf', 'linux-aarch64']]@
+tmpd=`mktemp -d`
+mkdir $tmpd/src
+curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o $tmpd/ros2.repos
+vcs import $tmpd/src --input $tmpd/ros2.repos
+export CI_ARGS="$CI_ARGS --src-mounted"
+export EXTRA_MOUNT="-v $tmpd/src:/home/rosbuild/ci_scripts/ws/src"
+@[end if]@
+@[if os_name == 'linux']@
+export CONTAINER_NAME=ros2_batch_ci
+@[elif os_name == 'linux-armhf']@
+export CONTAINER_NAME=ros2_batch_ci_armhf
+@[elif os_name == 'linux-aarch64']@
+export CONTAINER_NAME=ros2_batch_ci_aarch64
+@[else]@
+@{ assert 'Unknown os_name: ' + os_name }@
+@[end if]@
+docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
+@[if os_name in ['linux-armhf', 'linux-aarch64']]@
+rm -rf $tmpd
+@[end if]@
 echo "# END SECTION"
 @[else]@
 echo "# BEGIN SECTION: Run script"

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -35,7 +35,7 @@
       <parserConfigurations/>
       <consoleParsers>
         <hudson.plugins.warnings.ConsoleParser>
-@[if os_name == 'linux']@
+@[if os_name in ['linux', 'linux-armhf', 'linux-aarch64']]@
           <parserName>GNU C Compiler 4 (gcc)</parserName>
 @[elif os_name == 'osx']@
           <parserName>Clang (LLVM based)</parserName>

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:trusty
 MAINTAINER William Woodall <william@osrfoundation.org>
+ARG PLATFORM=x86
 
 # Prevent errors from apt-get.
 # See: http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
@@ -9,7 +10,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 # Get curl for fetching the repo keys.
-RUN apt-get install -y curl
+RUN apt-get update && apt-get install -y curl
 
 # Get https transport for APT.
 RUN apt-get install -y apt-transport-https
@@ -23,8 +24,9 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` 
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | sudo apt-key add -
 
 # Add the Git-LFS repository.
-RUN echo "deb https://packagecloud.io/github/git-lfs/ubuntu/ `lsb_release -cs` main" > /etc/apt/sources.list.d/github_git-lfs.list
-RUN curl --silent https://packagecloud.io/gpg.key | sudo apt-key add -
+RUN echo "platform: ${PLATFORM}"
+RUN if test ${PLATFORM} = x86; then echo "deb https://packagecloud.io/github/git-lfs/ubuntu/ `lsb_release -cs` main" > /etc/apt/sources.list.d/github_git-lfs.list; fi
+RUN if test ${PLATFORM} = x86; then curl --silent https://packagecloud.io/gpg.key | sudo apt-key add -; fi
 
 # Install some development tools.
 RUN apt-get update && apt-get install -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
@@ -42,7 +44,7 @@ RUN apt-get update && apt-get install -y libopensplice64
 RUN sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml
 
 # Install the RTI dependencies.
-RUN apt-get update && apt-get install -y default-jre-headless
+RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y default-jre-headless; fi
 
 # Add and install the RTI binaries we made.
 ADD rticonnextdds-src/librticonnextdds52_5.2.0-1_amd64.deb /tmp/librticonnextdds52_5.2.0-1_amd64.deb
@@ -56,7 +58,7 @@ RUN apt-get update && apt-get install -y libboost-chrono-dev libboost-date-time-
 RUN apt-get update && apt-get install -y libopencv-dev
 
 # Install Git-LFS.
-RUN apt-get update && apt-get install -y git-lfs
+RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi
 
 # Install Python3 development files.
 RUN apt-get update && apt-get install -y python3-dev

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -26,7 +26,9 @@ ifconfig eth0 multicast
 echo "done."
 
 echo "Initializing Git-LFS..."
-sudo -H -u rosbuild -- git lfs install
+if ! sudo -H -u rosbuild -- git lfs install; then
+  echo "Git-LFS failed to initialize (this is expected on ARM platforms)."
+fi
 echo "done."
 
 case "${CI_ARGS}" in


### PR DESCRIPTION
This PR adds support for building 32-bit and 64-bit ARM on the ROS 2 build farm.

Notes:

* I used `armhf` and `aarch64` to refer to the two platforms. That pair is one of the many competing naming schemes that are in use. I'm happy to rename if there's some other scheme that we're using.
* We're building for ARM by using docker images that run everything under qemu.
* `git` doesn't work inside `qemu`. As a result we need to pull the code outside docker and mount it in. To support this use case, I added the option `--src-mounted` to the `run_ros2_batch.py` script. In that case, it skips all the `vcs`-related steps. The config for the ARM jobs does the pulling and mounting before running the container.
* I'm only testing so far with OpenSplice because we have armhf and aarch64 debs for it. We can expand to other DDS vendors over time.
* I'm only creating manual CI jobs, which are not launched by the `ci_launcher` job. We can add other jobs over time, but because of the length of time required to run ARM/qemu builds, we'll probably never want to use them for pre-merge CI testing.
* A not-strictly-related, but useful, change in this PR is modifying the jobs to use labels (e.g., `linux`) rather than specific machine names (e.g., `linux_slave_on_master`). That way, e.g., a linux job will run on the first available linux machine. I've changed all the slaves to have the right labels.

The first armhf build is here: http://ci.ros2.org/job/ci_linux-armhf/4. So far, it's gotten through the build successfully and is running tests. I'll kick off aarch64 when armhf done.