### PR TITLE
allow concurrent CI builds

### DIFF
--- a/job_templates/ci_job.xml.template
+++ b/job_templates/ci_job.xml.template
@@ -67,7 +67,7 @@
     </hudson.triggers.TimerTrigger>
   @
 @[end if]</triggers>
-  <concurrentBuild>false</concurrentBuild>
+  <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@1.27">
       <scriptSource class="hudson.plugins.groovy.StringScriptSource">


### PR DESCRIPTION
With multiple executors per platform we need to enable concurrent builds to run more than one build at a time.

(That also allows us implicitly to run a job on the executor you want. Just trigger a job twice and abort the undesired one :wink:)