### PR TITLE
Check ROS_DOMAIN_ID before setting

### DIFF
--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -26,7 +26,9 @@ class LinuxBatchJob(BatchJob):
         BatchJob.__init__(self)
 
     def pre(self):
-        os.environ['ROS_DOMAIN_ID'] = '108'
+        # Check if ROS_DOMAIN_ID was already set in the environment
+        if 'ROS_DOMAIN_ID' not in os.environ:
+            os.environ['ROS_DOMAIN_ID'] = '108'
         # Check for ccache's directory, as installed by apt-get
         ccache_exe_dir = '/usr/lib/ccache'
         if os.path.isdir(ccache_exe_dir):

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -36,7 +36,8 @@ class OSXBatchJob(BatchJob):
             warn('ccache does not appear to be installed; not modifying PATH')
         if 'LANG' not in os.environ:
             os.environ['LANG'] = 'en_US.UTF-8'
-        os.environ['ROS_DOMAIN_ID'] = '111'
+        if 'ROS_DOMAIN_ID' not in os.environ:
+            os.environ['ROS_DOMAIN_ID'] = '111'
 
     def show_env(self):
         # Show the env

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -27,7 +27,8 @@ class WindowsBatchJob(BatchJob):
         BatchJob.__init__(self)
 
     def pre(self):
-        os.environ['ROS_DOMAIN_ID'] = '119'
+        if 'ROS_DOMAIN_ID' not in os.environ:
+            os.environ['ROS_DOMAIN_ID'] = '119'
 
     def show_env(self):
         # Show the env


### PR DESCRIPTION
Right now all CI jobs for the same OS set the same ROS_DOMAIN_ID. This could cause problems with concurrent jobs. This pull request changes the ci scripts not to overwrite ROS_DOMAIN_ID if it already exists.

fun fact, I had to submit this pull request manually using the Github web API because the website UI was broken and wasn't displaying a pull request button.