### PR TITLE
Make the launcher job also inherit the defaults used for other jobs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -170,12 +170,11 @@ def main(argv=None):
         os_specific_data[os_name] = dict(data)
         os_specific_data[os_name].update(os_configs[os_name])
         os_specific_data[os_name]['job_name'] = 'ci_' + os_name
-    job_data = {
-        'ci_scripts_default_branch': args.ci_scripts_default_branch,
-        'label_expression': 'master',
-        'os_specific_data': os_specific_data,
-        'cmake_build_type': 'None',
-    }
+    job_data = dict(data)
+    job_data['ci_scripts_default_branch'] = args.ci_scripts_default_branch
+    job_data['label_expression'] = 'master'
+    job_data['os_specific_data'] = os_specific_data
+    job_data['cmake_build_type'] = 'None'
     job_config = expand_template('ci_launcher_job.xml.template', job_data)
     configure_job(jenkins, 'ci_launcher', job_config, **jenkins_kwargs)
 

--- a/job_templates/ci_launcher_job.xml.template
+++ b/job_templates/ci_launcher_job.xml.template
@@ -9,13 +9,13 @@
 @(SNIPPET(
     'property_parameter-definition',
     ci_scripts_default_branch=ci_scripts_default_branch,
-    use_connext_default='true',
-    disable_connext_static_default='false',
-    disable_connext_dynamic_default='false',
-    use_fastrtps_default='true',
-    use_opensplice_default='true',
+    use_connext_default=use_connext_default,
+    disable_connext_static_default=disable_connext_static_default,
+    disable_connext_dynamic_default=disable_connext_dynamic_default,
+    use_fastrtps_default=use_fastrtps_default,
+    use_opensplice_default=use_opensplice_default,
     cmake_build_type=cmake_build_type,
-    ament_args_default='',
+    ament_args_default=ament_args_default,
 ))@
     <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.25">
       <autoRebuild>false</autoRebuild>


### PR DESCRIPTION
@dirk-thomas discovered that, following #229, the launcher job was still using the old defaults. That's because that job is configured manually in the job creation script in a manner that doesn't use those defaults, and then the launcher job template has its own hard-coded defaults. This PR makes the launcher job inherit the same defaults used elsewhere.

It's deployed on the farm, which resulted, as expected, in this single-line change to the launcher job config (changing connext from default on to default off):

```
Updating job 'ci_launcher'
    <<<
    --- remote config
    +++ new config
    @@ -38 +38 @@
    -          <defaultValue>true</defaultValue>
    +          <defaultValue>false</defaultValue>
    >>>
```