### PR TITLE
use Connext 5.2.3 on OS X and Windows

### DIFF
--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -52,8 +52,8 @@ class OSXBatchJob(BatchJob):
         if self.args.connext:
             # Try to find the connext env file and source it
             connext_env_file = os.path.join(
-                '/Applications', 'rti_connext_dds-5.2.0', 'resource', 'scripts',
-                'rtisetenv_x64Darwin14clang6.0.bash')
+                '/Applications', 'rti_connext_dds-5.2.3', 'resource', 'scripts',
+                'rtisetenv_x64Darwin15clang7.0.bash')
             if not os.path.exists(connext_env_file):
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
                     connext_env_file))

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -42,7 +42,7 @@ class WindowsBatchJob(BatchJob):
         if self.args.connext:
             pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
             connext_env_file = os.path.join(
-                pf, 'rti_connext_dds-5.2.0', 'resource', 'scripts', 'rtisetenv_X64Win64VS2013.bat')
+                pf, 'rti_connext_dds-5.2.3', 'resource', 'scripts', 'rtisetenv_X64Win64VS2015.bat')
             if not os.path.exists(connext_env_file):
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
                     connext_env_file))


### PR DESCRIPTION
No regressions as far as I can see (beside the known Connext Dynamic failures on Windows):

* OS X:
  * Dosa http://ci.ros2.org/job/ci_osx/1099/
  * Robbie http://ci.ros2.org/job/ci_osx/1100

* Windows:
  * Windshield http://ci.ros2.org/job/ci_windows/1425/
  * Eatable http://ci.ros2.org/job/ci_windows/1426/