### PR TITLE
Enable C++ coverage reports using gcov

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -73,6 +73,7 @@ def main(argv=None):
         'use_fastrtps_default': 'true',
         'use_opensplice_default': 'false',
         'ament_args_default': '',
+        'enable_c_coverage_default': 'false',
     }
 
     jenkins = connect(args.jenkins_url)
@@ -143,6 +144,14 @@ def main(argv=None):
         job_data['cmake_build_type'] = 'Debug'
         job_config = expand_template('ci_job.xml.template', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+
+        # configure nightly coverage job on Linux only
+        if os_name == 'linux':
+            job_name = 'nightly_' + os_name + '_coverage'
+            job_data['cmake_build_type'] = 'Debug'
+            job_data['enable_c_coverage_default'] = 'true'
+            job_config = expand_template('ci_job.xml.template', job_data)
+            configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
         # configure nightly triggered job
         job_name = 'nightly_' + os_name + '_release'

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -152,6 +152,7 @@ def main(argv=None):
             job_data['enable_c_coverage_default'] = 'true'
             job_config = expand_template('ci_job.xml.template', job_data)
             configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+            job_data['enable_c_coverage_default'] = 'false'
 
         # configure nightly triggered job
         job_name = 'nightly_' + os_name + '_release'

--- a/job_templates/ci_job.xml.template
+++ b/job_templates/ci_job.xml.template
@@ -83,7 +83,8 @@ repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_REPOS_URL')}, <br/>
 use_whitespace: ${build.buildVariableResolver.resolve('CI_USE_WHITESPACE_IN_PATHS')}, <br/>
 isolated: ${build.buildVariableResolver.resolve('CI_ISOLATED')}, <br/>
 cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')}, <br/>
-ament_args: ${build.buildVariableResolver.resolve('CI_AMENT_ARGS')}\
+ament_args: ${build.buildVariableResolver.resolve('CI_AMENT_ARGS')}, <br/>
+coverage: ${build.buildVariableResolver.resolve('CI_COVERAGE')}\
 """);]]>
         </command>
       </scriptSource>
@@ -129,6 +130,9 @@ if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then
 fi
 if [ -n "${CI_AMENT_ARGS+x}" ]; then
   export CI_ARGS="$CI_ARGS --ament-args $CI_AMENT_ARGS"
+fi
+if [ -n "${CI_COVERAGE}" ]; then
+  export CI_ARGS="$CI_ARGS --coverage"
 fi
 echo "Using args: $CI_ARGS"
 echo "# END SECTION"
@@ -222,6 +226,9 @@ if "%CI_CMAKE_BUILD_TYPE%" NEQ "None" (
 if "%CI_AMENT_ARGS%" NEQ "" (
   set "CI_ARGS=%CI_ARGS% --ament-args %CI_AMENT_ARGS%"
 )
+if "%CI_COVERAGE%" == "true" (
+  set "CI_ARGS=%CI_ARGS% --coverage"
+)
 echo Using args: %CI_ARGS%
 echo "# END SECTION"
 
@@ -239,7 +246,7 @@ echo "# END SECTION"
     os_name=os_name,
 ))@
     <hudson.plugins.cobertura.CoberturaPublisher plugin="cobertura@@1.9.7">
-      <coberturaReportFile>ws/build*/*/coverage.xml</coberturaReportFile>
+      <coberturaReportFile>ws/build*/**/*coverage.xml</coberturaReportFile>
       <onlyStable>false</onlyStable>
       <failUnhealthy>false</failUnhealthy>
       <failUnstable>false</failUnstable>

--- a/job_templates/ci_job.xml.template
+++ b/job_templates/ci_job.xml.template
@@ -18,6 +18,7 @@
     use_opensplice_default=use_opensplice_default,
     cmake_build_type=cmake_build_type,
     ament_args_default=ament_args_default,
+    enable_c_coverage_default=enable_c_coverage_default,
 ))@
     <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.25">
       <autoRebuild>false</autoRebuild>
@@ -84,7 +85,7 @@ use_whitespace: ${build.buildVariableResolver.resolve('CI_USE_WHITESPACE_IN_PATH
 isolated: ${build.buildVariableResolver.resolve('CI_ISOLATED')}, <br/>
 cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')}, <br/>
 ament_args: ${build.buildVariableResolver.resolve('CI_AMENT_ARGS')}, <br/>
-coverage: ${build.buildVariableResolver.resolve('CI_COVERAGE')}\
+coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
 """);]]>
         </command>
       </scriptSource>
@@ -131,7 +132,7 @@ fi
 if [ -n "${CI_AMENT_ARGS+x}" ]; then
   export CI_ARGS="$CI_ARGS --ament-args $CI_AMENT_ARGS"
 fi
-if [ -n "${CI_COVERAGE}" ]; then
+if [ -n "${CI_ENABLE_C_COVERAGE}" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
 fi
 echo "Using args: $CI_ARGS"
@@ -226,7 +227,7 @@ if "%CI_CMAKE_BUILD_TYPE%" NEQ "None" (
 if "%CI_AMENT_ARGS%" NEQ "" (
   set "CI_ARGS=%CI_ARGS% --ament-args %CI_AMENT_ARGS%"
 )
-if "%CI_COVERAGE%" == "true" (
+if "%CI_ENABLE_C_COVERAGE%" == "true" (
   set "CI_ARGS=%CI_ARGS% --coverage"
 )
 echo Using args: %CI_ARGS%

--- a/job_templates/ci_launcher_job.xml.template
+++ b/job_templates/ci_launcher_job.xml.template
@@ -16,6 +16,7 @@
     use_opensplice_default=use_opensplice_default,
     cmake_build_type=cmake_build_type,
     ament_args_default=ament_args_default,
+    enable_c_coverage_default=enable_c_coverage_default,
 ))@
     <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.25">
       <autoRebuild>false</autoRebuild>

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -57,6 +57,11 @@ This tests the robustness to whitespace being within the different paths.</descr
           <description>By setting this to True, the build will use the --isolated option.</description>
           <defaultValue>true</defaultValue>
         </hudson.model.BooleanParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
+          <name>CI_ENABLE_C_COVERAGE</name>
+          <description>By setting this to true, the build will report test coverage for C/C++ code (currently ignored on non-Linux).</description>
+          <defaultValue>@(enable_c_coverage_default)</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_CMAKE_BUILD_TYPE</name>
           <description>Select the CMake build type.</description>

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -41,6 +41,9 @@ RUN apt-get update && apt-get install -y clang-format-3.8 cppcheck git pydocstyl
 RUN apt-get update && apt-get install -y python3-pip
 RUN pip3 install -U setuptools pip virtualenv
 
+# Install coverage build dependencies.
+RUN apt-get update && apt-get install -y gcovr
+
 # Install the OpenSplice binary from the OSRF repositories.
 RUN apt-get update && apt-get install -y libopensplice64
 # Update default domain id.


### PR DESCRIPTION
In progress.

Right now coverage is toggled with a new parameter on Jenkins, CI_COVERAGE, which is off by default. I can change that to a different path (e.g. a different job template type) if we think that's appropriate.

This build should show what the coverage results will look like on Jenkins.

http://ci.ros2.org/job/ci_linux/1457/

Connects to #230