### PR TITLE
use Connext 5.2.3 Debian package

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -50,9 +50,9 @@ RUN sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y default-jre-headless; fi
 
 # Add and install the RTI binaries we made.
-ADD rticonnextdds-src/librticonnextdds52_5.2.0-1_amd64.deb /tmp/librticonnextdds52_5.2.0-1_amd64.deb
-ADD rticonnextdds-src/librticonnextdds52-dev_5.2.0-1_amd64.deb /tmp/librticonnextdds52-dev_5.2.0-1_amd64.deb
-ADD rticonnextdds-src/rticonnextdds-tools_5.2.0-1_amd64.deb /tmp/rticonnextdds-tools_5.2.0-1_amd64.deb
+ADD rticonnextdds-src/librticonnextdds52_5.2.3-1_amd64.deb /tmp/librticonnextdds52_5.2.3-1_amd64.deb
+ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
+ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
 
 # Install the eProsima dependencies.
 RUN apt-get update && apt-get install -y libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -34,9 +34,9 @@ echo "done."
 case "${CI_ARGS}" in
   *--connext*)
     echo "Installing Connext..."
-    dpkg -i /tmp/librticonnextdds52_5.2.0-1_amd64.deb
-    dpkg -i /tmp/librticonnextdds52-dev_5.2.0-1_amd64.deb
-    dpkg -i /tmp/rticonnextdds-tools_5.2.0-1_amd64.deb
+    dpkg -i /tmp/librticonnextdds52_5.2.3-1_amd64.deb
+    dpkg -i /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
+    dpkg -i /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
     echo "done."
     ;;
   *)

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -50,7 +50,7 @@ class LinuxBatchJob(BatchJob):
         if self.args.connext:
             # Try to find the connext env file and source it
             connext_env_file = os.path.join(
-                os.path.expanduser('~'), 'rti_connext_dds-5.2.0', 'resource', 'scripts',
+                os.path.expanduser('~'), 'rti_connext_dds-5.2.3', 'resource', 'scripts',
                 'rtisetenv_x64Linux3.xgcc4.6.3.bash')
             if not os.path.exists(connext_env_file):
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(


### PR DESCRIPTION
Using the new (internal) Debian package of Connext 5.2.3 on Jenkins: http://ci.ros2.org/job/ci_linux/1476/

Please review.