### PR TITLE
add valgrind to Linux Dockerfile

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -55,7 +55,7 @@ ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnex
 ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
 
 # Install the eProsima dependencies.
-RUN apt-get update && apt-get install -y libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev
+RUN apt-get update && apt-get install -y libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev valgrind
 
 # Install OpenCV.
 RUN apt-get update && apt-get install -y libopencv-dev


### PR DESCRIPTION
We can either install `valgrind` on the OS X slaves manually or hope that eProsima/Fast-RTPS#49 gets addressed and live with the failing tests until then.

http://ci.ros2.org/job/ci_linux/1510/