### PR TITLE
adjust CI defaults to match new targets

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -125,7 +125,11 @@ def main(argv=None):
 
         # all following jobs are triggered nightly with email notification
         job_data['time_trigger_spec'] = '0 11 * * *'
-        job_data['mailer_recipients'] = 'ros@osrfoundation.org'
+        # for now, skip emailing about Windows failures
+        if os_name != 'windows':
+            job_data['mailer_recipients'] = 'ros@osrfoundation.org'
+        else:
+            job_data['mailer_recipients'] = ''
 
         # configure packaging job
         job_name = 'packaging_' + os_name

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -126,10 +126,7 @@ def main(argv=None):
         # all following jobs are triggered nightly with email notification
         job_data['time_trigger_spec'] = '0 11 * * *'
         # for now, skip emailing about Windows failures
-        if os_name != 'windows':
-            job_data['mailer_recipients'] = 'ros@osrfoundation.org'
-        else:
-            job_data['mailer_recipients'] = ''
+        job_data['mailer_recipients'] = 'ros@osrfoundation.org' if os_name != 'windows' else ''
 
         # configure packaging job
         job_name = 'packaging_' + os_name

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -164,6 +164,9 @@ def main(argv=None):
     # configure the launch job
     os_specific_data = collections.OrderedDict()
     for os_name in sorted(os_configs.keys()):
+        # skip windows for now
+        if os_name == 'windows':
+            continue
         # skip non-manual jobs on ARM for now
         if os_name == 'linux-armhf' or os_name == 'linux-aarch64':
             continue

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -67,11 +67,11 @@ def main(argv=None):
         'ci_scripts_default_branch': args.ci_scripts_default_branch,
         'time_trigger_spec': '',
         'mailer_recipients': '',
-        'use_connext_default': 'false',
+        'use_connext_default': 'true',
         'disable_connext_static_default': 'false',
-        'disable_connext_dynamic_default': 'false',
+        'disable_connext_dynamic_default': 'true',
         'use_fastrtps_default': 'true',
-        'use_opensplice_default': 'true',
+        'use_opensplice_default': 'false',
         'ament_args_default': '',
     }
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -304,7 +304,7 @@ def run(args, build_function):
                 # Store current branch as well-known branch name for later rebasing
                 info('Attempting to create a well known branch name for all the default branches')
                 job.run(vcs_cmd + ['custom', '.', '--git', '--args', 'checkout', '-b', '__ci_default'])
-    
+
                 # Attempt to switch all the repositories to a given branch
                 info("Attempting to switch all repositories to the '{0}' branch"
                      .format(args.test_branch))
@@ -315,7 +315,7 @@ def run(args, build_function):
                 ret = job.run(vcs_custom_cmd, exit_on_error=False)
                 info("'{0}' returned exit code '{1}'", fargs=(" ".join(vcs_custom_cmd), ret))
                 print()
-    
+
                 # Attempt to rebase all the repositories to the __ci_default branch
                 info("Attempting to rebase all repositories to the '__ci_default' branch")
                 vcs_custom_cmd = vcs_cmd + ['custom', '.', '--git', '--args', 'rebase', '__ci_default']
@@ -323,7 +323,7 @@ def run(args, build_function):
                 info("'{0}' returned exit code '{1}'", fargs=(" ".join(vcs_custom_cmd), ret))
                 print()
                 print('# END SUBSECTION')
-    
+
             print('# BEGIN SUBSECTION: repository hashes')
             # Show the latest commit log on each repository (includes the commit hash).
             job.run(vcs_cmd + ['log', '-l1', '"%s"' % args.sourcespace], shell=True)


### PR DESCRIPTION
This pull request:

- disables opensplice by default in CI jobs
- enables connext_static by default in CI jobs
- disables connext_dynamic by default in CI jobs
- changes ci_launcher to not launch a Windows CI job
- disabled emails about Windows nightly failures

I did not deploy this on the farm because it would have overwritten some coverage changes that are being tested but that have not been merged yet, see: https://github.com/ros2/ros2/pull/234

This matches, to the best of my understanding, our new default acceptance criteria for CI and nightlies.