### PR TITLE
fix condition on coverage variable

### DIFF
--- a/job_templates/ci_job.xml.template
+++ b/job_templates/ci_job.xml.template
@@ -132,7 +132,7 @@ fi
 if [ -n "${CI_AMENT_ARGS+x}" ]; then
   export CI_ARGS="$CI_ARGS --ament-args $CI_AMENT_ARGS"
 fi
-if [ -n "${CI_ENABLE_C_COVERAGE}" ]; then
+if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
 fi
 echo "Using args: $CI_ARGS"


### PR DESCRIPTION
The old code was checking for non-zero-length instead of comparing against true. The result was that `--coverage` was being passed every time, which had the effect of making all Linux builds do coverage.

This change has been deployed to the farm.