### PR TITLE
add CMake warning parser

### DIFF
--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -35,6 +35,9 @@
       <parserConfigurations/>
       <consoleParsers>
         <hudson.plugins.warnings.ConsoleParser>
+          <parserName>CMake</parserName>
+        </hudson.plugins.warnings.ConsoleParser>
+        <hudson.plugins.warnings.ConsoleParser>
 @[if os_name in ['linux', 'linux-armhf', 'linux-aarch64']]@
           <parserName>GNU C Compiler 4 (gcc)</parserName>
 @[elif os_name == 'osx']@


### PR DESCRIPTION
Use the new regular expression / Groovy script (configured globally) to extract CMake warnings and errors.