### PR TITLE
fix unicode problem on Windows

### DIFF
--- a/ros2_batch_job/util.py
+++ b/ros2_batch_job/util.py
@@ -170,10 +170,10 @@ class MyProtocol(AsyncSubprocessProtocol):
         AsyncSubprocessProtocol.__init__(self, *args, **kwargs)
 
     def on_stdout_received(self, data):
-        sys.stdout.write(data.decode().replace(os.linesep, '\n'))
+        sys.stdout.write(data.decode('utf-8', 'replace').replace(os.linesep, '\n'))
 
     def on_stderr_received(self, data):
-        sys.stderr.write(data.decode().replace(os.linesep, '\n'))
+        sys.stderr.write(data.decode('utf-8', 'replace').replace(os.linesep, '\n'))
 
     def on_process_exited(self, returncode):
         if self.exit_on_error and returncode != 0:


### PR DESCRIPTION
This should fix the traceback in the Windows builds: http://ci.ros2.org/view/nightly/job/nightly_win_deb/165/consoleFull#console-section-2