### PR TITLE
add ament_cmake_ros repo

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -51,6 +51,10 @@ repositories:
     type: git
     url: https://github.com/ros/geometry2.git
     version: ros2
+  ros2/ament_cmake_ros:
+    type: git
+    url: https://github.com/ros2/ament_cmake_ros.git
+    version: master
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git


### PR DESCRIPTION
The new repo [ament_cmake_ros](https://github.com/ros2/ament_cmake_ros) contains the CMake option `BUILD_SHARED_LIBS` which defaults to `ON` (rather than `OFF` which is the CMake default). I think this is a cleaner approach then to modify `ament_tools` as proposed in ament/ament_tools#128 since even when the packages are being built with `cmake && make && make install` they behave the same.

Please review.