### PR TITLE
add cli_tools

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -55,6 +55,10 @@ repositories:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
     version: master
+  ros2/cli_tools:
+    type: git
+    url: https://github.com/ros2/cli_tools.git
+    version: master
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -55,6 +55,10 @@ repositories:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
     version: master
+  ros2/c_utilities:
+    type: git
+    url: https://github.com/ros2/c_utilities.git
+    version: master
   ros2/cli_tools:
     type: git
     url: https://github.com/ros2/cli_tools.git


### PR DESCRIPTION
Now that we're starting to use it, add the `cli_tools` repo to the standard repos file, so that it's in everybody's checkout and getting linted and tested. Related to ros2/cli_tools#2