### PR TITLE
Move geometry2 (both locally, and on github).

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -47,9 +47,9 @@ repositories:
     type: git
     url: https://github.com/ros/class_loader.git
     version: ros2
-  ros/geometry2:
+  ros2/geometry2:
     type: git
-    url: https://github.com/ros/geometry2.git
+    url: https://github.com/ros2/geometry2.git
     version: ros2
   ros2/ament_cmake_ros:
     type: git

--- a/ros2.repos
+++ b/ros2.repos
@@ -47,10 +47,6 @@ repositories:
     type: git
     url: https://github.com/ros/class_loader.git
     version: ros2
-  ros2/geometry2:
-    type: git
-    url: https://github.com/ros2/geometry2.git
-    version: ros2
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
@@ -75,6 +71,10 @@ repositories:
     type: git
     url: https://github.com/ros2/examples.git
     version: master
+  ros2/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: ros2
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git


### PR DESCRIPTION
We want to switch to using our fork, instead of a branch on
the original.  This matches what we do for other repositories.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>