### PR TITLE
Robot state publisher

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -70,7 +70,7 @@ repositories:
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: dummy_robot_demo
+    version: master
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
@@ -79,6 +79,10 @@ repositories:
     type: git
     url: https://github.com/ros2/launch.git
     version: master
+  ros2/orocos_kinematics_dynamics:
+    type: git
+    url: https://github.com/ros2/orocos_kinematics_dynamics.git
+    version: ros2
   ros2/poco_vendor:
     type: git
     url: https://github.com/ros2/poco_vendor.git
@@ -127,6 +131,14 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_opensplice.git
     version: master
+  ros2/robot_model:
+    type: git
+    url: https://github.com/ros2/robot_model.git
+    version: ros2
+  ros2/robot_state_publisher:
+    type: git
+    url: https://github.com/ros2/robot_state_publisher.git
+    version: ros2
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git
@@ -147,6 +159,10 @@ repositories:
     type: git
     url: https://github.com/ros2/system_tests.git
     version: master
+  ros2/tinyxml_vendor:
+    type: git
+    url: https://github.com/ros2/tinyxml_vendor.git
+    version: master
   ros2/tlsf:
     type: git
     url: https://github.com/ros2/tlsf.git
@@ -155,14 +171,6 @@ repositories:
 #    type: git
 #    url: https://github.com/ros2/tutorials.git
 #    version: master
-  vendor/console_bridge:
-    type: git
-    url: https://github.com/ros/console_bridge.git
-    version: master
-  ros2/tinyxml_vendor:
-    type: git
-    url: https://github.com/ros2/tinyxml_vendor.git
-    version: master
   ros2/urdfdom:
     type: git
     url: https://github.com/ros2/urdfdom.git
@@ -171,15 +179,7 @@ repositories:
     type: git
     url: https://github.com/ros2/urdfdom_headers.git
     version: math_h
-  ros2/robot_model:
+  vendor/console_bridge:
     type: git
-    url: https://github.com/ros2/robot_model.git
-    version: ros2
-  ros2/robot_state_publisher:
-    type: git
-    url: https://github.com/ros2/robot_state_publisher.git
-    version: ros2
-  ros2/orocos_kinematics_dynamics:
-    type: git
-    url: https://github.com/ros2/orocos_kinematics_dynamics.git
-    version: ros2
+    url: https://github.com/ros/console_bridge.git
+    version: master

--- a/ros2.repos
+++ b/ros2.repos
@@ -159,3 +159,27 @@ repositories:
     type: git
     url: https://github.com/ros/console_bridge.git
     version: master
+  ros2/tinyxml_vendor:
+    type: git
+    url: https://github.com/ros2/tinyxml_vendor.git
+    version: master
+  ros2/urdfdom:
+    type: git
+    url: https://github.com/ros2/urdfdom.git
+    version: ros2
+  ros/urdfdom_headers:
+    type: git
+    url: https://github.com/ros/urdfdom_headers.git
+    version: master
+  ros2/robot_model:
+    type: git
+    url: https://github.com/ros2/robot_model.git
+    version: ros2
+  ros2/robot_state_publisher:
+    type: git
+    url: https://github.com/ros2/robot_state_publisher.git
+    version: ros2
+  ros2/orocos_kinematics_dynamics:
+    type: git
+    url: https://github.com/ros2/orocos_kinematics_dynamics.git
+    version: ros2

--- a/ros2.repos
+++ b/ros2.repos
@@ -50,7 +50,7 @@ repositories:
   ros/geometry2:
     type: git
     url: https://github.com/ros/geometry2.git
-    version: ros2
+    version: fix_build_karsten
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
@@ -70,7 +70,7 @@ repositories:
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: master
+    version: dummy_robot_demo
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -70,7 +70,7 @@ repositories:
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: dummy_robot_demo
+    version: master
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -162,7 +162,7 @@ repositories:
   ros2/tinyxml_vendor:
     type: git
     url: https://github.com/ros2/tinyxml_vendor.git
-    version: ros2
+    version: master
   ros2/urdfdom:
     type: git
     url: https://github.com/ros2/urdfdom.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -50,7 +50,7 @@ repositories:
   ros/geometry2:
     type: git
     url: https://github.com/ros/geometry2.git
-    version: fix_build_karsten
+    version: fix_build2
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -161,16 +161,16 @@ repositories:
     version: master
   ros2/tinyxml_vendor:
     type: git
-    url: https://github.com/ros2/tinyxml_vendor.git
-    version: master
+    url: https://github.com/nuclearsandwich/tinyxml_vendor.git
+    version: look-for-config-package-in-find-module
   ros2/urdfdom:
     type: git
     url: https://github.com/ros2/urdfdom.git
     version: ros2
   ros/urdfdom_headers:
     type: git
-    url: https://github.com/ros/urdfdom_headers.git
-    version: master
+    url: https://github.com/ros2/urdfdom_headers.git
+    version: math_h
   ros2/robot_model:
     type: git
     url: https://github.com/ros2/robot_model.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -161,7 +161,7 @@ repositories:
     version: master
   ros2/tinyxml_vendor:
     type: git
-    url: https://github.com/nuclearsandwich/tinyxml_vendor.git
+    url: https://github.com/ros2/tinyxml_vendor.git
     version: look-for-config-package-in-find-module
   ros2/urdfdom:
     type: git

--- a/ros2.repos
+++ b/ros2.repos
@@ -50,7 +50,7 @@ repositories:
   ros/geometry2:
     type: git
     url: https://github.com/ros/geometry2.git
-    version: fix_build2
+    version: ros2
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
@@ -70,7 +70,7 @@ repositories:
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: master
+    version: dummy_robot_demo
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
@@ -162,7 +162,7 @@ repositories:
   ros2/tinyxml_vendor:
     type: git
     url: https://github.com/ros2/tinyxml_vendor.git
-    version: look-for-config-package-in-find-module
+    version: ros2
   ros2/urdfdom:
     type: git
     url: https://github.com/ros2/urdfdom.git


### PR DESCRIPTION
This adds the robot_state_publisher and its dependencies for the `robot_state_publisher`.

This connects to https://github.com/ros2/demos/pull/118