### PR TITLE
use ros2 branch for urdfdom_headers

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -182,7 +182,7 @@ repositories:
   ros2/urdfdom_headers:
     type: git
     url: https://github.com/ros2/urdfdom_headers.git
-    version: math_h
+    version: ros2
   ros2/vision_opencv:
     type: git
     url: https://github.com/ros2/vision_opencv.git


### PR DESCRIPTION
connects to ros2/urdfdom_headers#1

I am changing the base branch of the `ros2/urdfdom_headers` to `ros2`. It need to do this temporarily to freely modify my PR of the  `math_h` branch in order to guarantee a stable ros2 master.

Even though there is no diff between `urdfdom_headers/math_h` and `urdfdom_headers/ros2`, I run CI (only on windows) to get sure:
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2687)](http://ci.ros2.org/job/ci_windows/2687/)