### PR TITLE
add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,13 +5,18 @@ For Bug report or feature requests, please fill out the relevant category below
 
 ## Bug report
 
-| Required Info | |
-|---|---|
-|Operating System|<!-- OS and version (e.g. Windows 10, Ubuntu 16.04...) -->|
-|Installation type|<!-- binaries or from source  -->|
-|Version or commit hash|<!-- Output of git rev-parse HEAD, release version or repos file  -->|
-|DDS implementation|<!-- rmw_implementation used (e.g. Fast-RTPS, RTI Connext, etc -->|
-|Client library (if applicable)|<!-- e.g. rclcpp, rclpy or N/A -->|
+**Required Info:**
+
+- Operating System:
+  - <!-- OS and version (e.g. Windows 10, Ubuntu 16.04...) -->
+- Installation type:
+  - <!-- binaries or from source  -->
+- Version or commit hash:
+  - <!-- Output of git rev-parse HEAD, release version, or repos file  -->
+- DDS implementation:
+  - <!-- rmw_implementation used (e.g. Fast-RTPS, RTI Connext, etc -->
+- Client library (if applicable):
+  - <!-- e.g. rclcpp, rclpy, or N/A -->
 
 #### Steps to reproduce issue
 <!-- Detailed instructions on how to reliably reproduce this issue http://sscce.org/
@@ -26,7 +31,8 @@ For Bug report or feature requests, please fill out the relevant category below
 
 #### Additional information
 
-
+<!-- If you are reporting a bug delete everything below
+     If you are requesting a feature deleted everything above this line -->
 ----
 ## Feature request
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -31,7 +31,7 @@ For Bug report or feature requests, please fill out the relevant category below
 ## Feature request
 
 #### Feature description
-<!-- Description in a few sentences what the feature consists in and what problem it will solve -->
+<!-- Description in a few sentences what the feature consists of and what problem it will solve -->
 
 #### Implementation considerations
-<!-- Relevant information of how the feature could be implemented and pros and cons of the different solutions -->
+<!-- Relevant information on how the feature could be implemented and pros and cons of the different solutions -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--
+For general questions, please post on discourse: https://discourse.ros.org/c/ng-ros
+For Bug report or feature requests, please fill out the relevant category below
+-->
+
+<!-- BUG REPORT -->
+## Bug report
+
+| Required Info | |
+|---|---|
+|Operating System|<!-- OS X/macOS, Ubuntu, or Windows, as well as version (e.g. Windows 10, Ubuntu 16.04) -->|
+|Installation type|<!-- binaries or from source  -->|
+|Version or commit hash|<!-- Output of git rev-parse HEAD, release version or repos file  -->|
+|DDS implementation|<!-- rmw_implementation use (e.g. Fast-RTPS, RTI Connext, etc -->|
+|Client library (if applicable)|<!-- e.g. rclcpp, rclpy or N/A -->|
+
+#### Steps to reproduce issue
+<!-- Detailed instructions on how to reliably reproduce this issue http://sscce.org/
+``` code that can be copy-pasted is preferred ``` -->
+```  ```
+
+#### Expected behavior
+<!-- Action or result expected from performing the steps above -->
+
+#### Actual behavior
+<!-- Action or result observed after performing the steps above -->
+
+#### Contributors with relevant knowledge or expertise (optional)
+<!-- @-mention individuals with knowledge in this problem domain -->
+
+#### Additional information
+<!-- If you want to give additional infromation describing the issue -->
+
+
+----
+<!-- FEATURE REQUEST -->
+## Feature request
+
+#### Feature description
+<!-- Description in a few sentences what the feature consists in and what problem it will solve -->
+
+#### Implementation considerations
+<!-- Relevant information of how the feature could be implemented and pros and cons of the different solutions -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,37 +3,31 @@ For general questions, please post on discourse: https://discourse.ros.org/c/ng-
 For Bug report or feature requests, please fill out the relevant category below
 -->
 
-<!-- BUG REPORT -->
 ## Bug report
 
 | Required Info | |
 |---|---|
-|Operating System|<!-- OS X/macOS, Ubuntu, or Windows, as well as version (e.g. Windows 10, Ubuntu 16.04) -->|
+|Operating System|<!-- OS and version (e.g. Windows 10, Ubuntu 16.04...) -->|
 |Installation type|<!-- binaries or from source  -->|
 |Version or commit hash|<!-- Output of git rev-parse HEAD, release version or repos file  -->|
-|DDS implementation|<!-- rmw_implementation use (e.g. Fast-RTPS, RTI Connext, etc -->|
+|DDS implementation|<!-- rmw_implementation used (e.g. Fast-RTPS, RTI Connext, etc -->|
 |Client library (if applicable)|<!-- e.g. rclcpp, rclpy or N/A -->|
 
 #### Steps to reproduce issue
 <!-- Detailed instructions on how to reliably reproduce this issue http://sscce.org/
 ``` code that can be copy-pasted is preferred ``` -->
-```  ```
+```
+
+```
 
 #### Expected behavior
-<!-- Action or result expected from performing the steps above -->
 
 #### Actual behavior
-<!-- Action or result observed after performing the steps above -->
-
-#### Contributors with relevant knowledge or expertise (optional)
-<!-- @-mention individuals with knowledge in this problem domain -->
 
 #### Additional information
-<!-- If you want to give additional infromation describing the issue -->
 
 
 ----
-<!-- FEATURE REQUEST -->
 ## Feature request
 
 #### Feature description


### PR DESCRIPTION
This adds a default issue template to the ros2/ros2 repo. To see what it looks like see https://github.com/mikaelarguedas/ros2/issues/new.
Looking for feedback on the content of the template and to know is we should propagate it to all repos in the ros2 organization.