### PR TITLE
replace cli_tools with ros2cli

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -51,10 +51,6 @@ repositories:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
     version: master
-  ros2/cli_tools:
-    type: git
-    url: https://github.com/ros2/cli_tools.git
-    version: master
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
@@ -146,6 +142,10 @@ repositories:
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git
+    version: master
+  ros2/ros2cli:
+    type: git
+    url: https://github.com/ros2/ros2cli.git
     version: master
   ros2/rosidl:
     type: git


### PR DESCRIPTION
Depends on ros2/ros2cli#1.

Since the repo `cli_tools` hasn't been part of the beta 1 release and is therefore not referenced anywhere I suggest to delete the repo once this PR has been merged.