### PR TITLE
use fork of console bridge with relocatable cmake files

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -197,5 +197,5 @@ repositories:
     version: ros2
   vendor/console_bridge:
     type: git
-    url: https://github.com/ros/console_bridge.git
-    version: master
+    url: https://github.com/nuclearsandwich/console_bridge.git
+    version: ros2-beta2

--- a/ros2.repos
+++ b/ros2.repos
@@ -197,5 +197,5 @@ repositories:
     version: ros2
   vendor/console_bridge:
     type: git
-    url: https://github.com/nuclearsandwich/console_bridge.git
-    version: ros2-beta2
+    url: https://github.com/ros2/console_bridge.git
+    version: ros2


### PR DESCRIPTION
This is needed for people to be able to build overlay ws on top of our packaging artifacts (see https://github.com/ros2/ros2/issues/310). This can be reverted once https://github.com/ros/console_bridge/pull/45 has been merged
@nuclearsandwich FYI