### PR TITLE
use upstream console bridge

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -51,6 +51,10 @@ repositories:
     type: git
     url: https://github.com/ros/class_loader.git
     version: ros2
+  ros/console_bridge:
+    type: git
+    url: https://github.com/ros/console_bridge.git
+    version: master
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
@@ -195,7 +199,3 @@ repositories:
     type: git
     url: https://github.com/ros2/vision_opencv.git
     version: ros2
-  vendor/console_bridge:
-    type: git
-    url: https://github.com/ros/console_bridge.git
-    version: master

--- a/ros2.repos
+++ b/ros2.repos
@@ -59,10 +59,6 @@ repositories:
     type: git
     url: https://github.com/ros2/common_interfaces.git
     version: master
-  ros2/console_bridge:
-    type: git
-    url: https://github.com/ros2/console_bridge.git
-    version: ros2
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
@@ -199,3 +195,7 @@ repositories:
     type: git
     url: https://github.com/ros2/vision_opencv.git
     version: ros2
+  vendor/console_bridge:
+    type: git
+    url: https://github.com/ros/console_bridge.git
+    version: master


### PR DESCRIPTION

https://github.com/ros/console_bridge/pull/45 has been merged, we can now track upstream again.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2930)](http://ci.ros2.org/job/ci_linux/2930/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=398)](http://ci.ros2.org/job/ci_linux-aarch64/398/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2374)](http://ci.ros2.org/job/ci_osx/2374/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3055)](http://ci.ros2.org/job/ci_windows/3055/)

Packaging:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=36)](http://ci.ros2.org/job/ci_packaging_linux/36/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=8)](http://ci.ros2.org/job/ci_packaging_linux-aarch64/8/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_osx&build=12)](http://ci.ros2.org/job/ci_packaging_osx/12/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=10)](http://ci.ros2.org/job/ci_packaging_windows/10/)

I tested locally to build an overlay with the artifact produces but the packaging job and it works.

connects to #310 
fixes #310