### PR TITLE
use googletest repo

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -23,14 +23,10 @@ repositories:
     type: git
     url: https://github.com/ament/ament_tools.git
     version: master
-  ament/gmock_vendor:
+  ament/googletest:
     type: git
-    url: https://github.com/ament/gmock_vendor.git
-    version: master
-  ament/gtest_vendor:
-    type: git
-    url: https://github.com/ament/gtest_vendor.git
-    version: master
+    url: https://github.com/ament/googletest.git
+    version: ros2
   ament/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Fixes ament/gtest_vendor#3 and ament/gmock_vendor#5.

After this has been merged the README in these two repos should be updated to mention that the repositories are not used anymore (ament/gtest_vendor#6, ament/gmock_vendor#6). We should keep them around in order to continue building older releases though.

The new fork has currently only two commits on the `ros2` branch:
* rename the existing `CMakeLists.txt` files (https://github.com/ament/googletest/commit/c93bee164573fe28bb38dcbd91eecc04a442ae73)
* add the package manifests as well as custom CMake files (https://github.com/ament/googletest/commit/eb77b54187d95024d37dce7201731637e5e42fb8)

CI builds including ament/ament_cmake#104:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2969)](http://ci.ros2.org/job/ci_linux/2969/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=409)](http://ci.ros2.org/job/ci_linux-aarch64/409/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2399)](http://ci.ros2.org/job/ci_osx/2399/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3079)](http://ci.ros2.org/job/ci_windows/3079/)