### PR TITLE
remove obsolete repo ament_python

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -15,10 +15,6 @@ repositories:
     type: git
     url: https://github.com/ament/ament_package.git
     version: master
-  ament/ament_python:
-    type: git
-    url: https://github.com/ament/ament_python.git
-    version: master
   ament/ament_tools:
     type: git
     url: https://github.com/ament/ament_tools.git


### PR DESCRIPTION
Connect to ament/ament_python#3.