### PR TITLE
Add in kdl_parser and urdf to the list of repositories.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -71,6 +71,10 @@ repositories:
     type: git
     url: https://github.com/ros2/geometry2.git
     version: ros2
+  ros2/kdl_parser:
+    type: git
+    url: https://github.com/ros2/kdl_parser.git
+    version: ros2
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -183,6 +183,10 @@ repositories:
 #    type: git
 #    url: https://github.com/ros2/tutorials.git
 #    version: master
+  ros2/urdf:
+    type: git
+    url: https://github.com/ros2/urdf.git
+    version: ros2
   ros2/urdfdom:
     type: git
     url: https://github.com/ros2/urdfdom.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -135,10 +135,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_opensplice.git
     version: master
-  ros2/robot_model:
-    type: git
-    url: https://github.com/ros2/robot_model.git
-    version: ros2
   ros2/robot_state_publisher:
     type: git
     url: https://github.com/ros2/robot_state_publisher.git


### PR DESCRIPTION
The motivation here is to only use the pieces that we need, and we only currently need kdl_parser and urdf.  So update to the latest kdl_parser and urdf (both of which have been split from robot_model), and apply the ros2 specific portions.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>