### PR TITLE
move vision_opencv to the turtlebot repos file as it is not used by a…

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -187,7 +187,3 @@ repositories:
     type: git
     url: https://github.com/ros2/urdfdom_headers.git
     version: ros2
-  ros2/vision_opencv:
-    type: git
-    url: https://github.com/ros2/vision_opencv.git
-    version: ros2


### PR DESCRIPTION
…ny demo in the core ros2.repos