### PR TITLE
Ignore rosidl_generator_py for cross-compilation

### DIFF
--- a/arm_crosscompilation/README.md
+++ b/arm_crosscompilation/README.md
@@ -46,7 +46,7 @@ You can do all of this with:
 ```
 sed -e '/py/ s/^#*/#/' -i src/ros2/rosidl_typesupport/rosidl_default_generators/CMakeLists.txt
 sed -i -r 's/<build(.+?py.+?)/<\!\-\-build\1\-\->/' src/ros2/rosidl_typesupport/rosidl_default_generators/package.xml
-touch src/ros2/geometry2/AMENT_IGNORE src/ros2/demos/AMENT_IGNORE src/ros2/orocos_kinematics_dynamics/AMENT_IGNORE src/ros2/rclpy/AMENT_IGNORE src/ros2/robot_model/AMENT_IGNORE src/ros2/robot_state_publisher/AMENT_IGNORE src/ros2/system_tests/AMENT_IGNORE src/ros2/urdfdom/AMENT_IGNORE src/ros2/urdfdom_headers/AMENT_IGNORE src/ros2/vision_opencv/AMENT_IGNORE src/ros2/examples/rclpy/AMENT_IGNORE src/ros2/rcl_interfaces/test_msgs/AMENT_IGNORE src/ros2/ros1_bridge/AMENT_IGNORE
+touch src/ros2/geometry2/AMENT_IGNORE src/ros2/demos/AMENT_IGNORE src/ros2/orocos_kinematics_dynamics/AMENT_IGNORE src/ros2/rclpy/AMENT_IGNORE src/ros2/robot_model/AMENT_IGNORE src/ros2/robot_state_publisher/AMENT_IGNORE src/ros2/system_tests/AMENT_IGNORE src/ros2/urdfdom/AMENT_IGNORE src/ros2/urdfdom_headers/AMENT_IGNORE src/ros2/vision_opencv/AMENT_IGNORE src/ros2/examples/rclpy/AMENT_IGNORE src/ros2/rcl_interfaces/test_msgs/AMENT_IGNORE src/ros2/ros1_bridge/AMENT_IGNORE src/ros2/rosidl/rosidl_generator_py/AMENT_IGNORE
 ```
 
 ## Trigger a build


### PR DESCRIPTION
ignore `rosidl_generator_py` for the cross-compilation because 1) python is not used now 2) this package break the build with `--build-tests`
connects to #427 