### PR TITLE
add pluginlib and tinyxml2_vendor to repos file

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -47,6 +47,10 @@ repositories:
     type: git
     url: https://github.com/ros/console_bridge.git
     version: master
+  ros/pluginlib:
+    type: git
+    url: https://github.com/ros/pluginlib.git
+    version: ros2
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
@@ -170,6 +174,10 @@ repositories:
   ros2/tinyxml_vendor:
     type: git
     url: https://github.com/ros2/tinyxml_vendor.git
+    version: master
+  ros2/tinyxml2_vendor:
+    type: git
+    url: https://github.com/ros2/tinyxml2_vendor.git
     version: master
   ros2/tlsf:
     type: git


### PR DESCRIPTION
This is a lead up to adding rviz.

I added `tinyxml2_vendor` because before version 5.0.1 of tinyxml2 there was not CMake config file provided by upstream. The vendor package, for now, downloads and builds tinyxml2 5.0.1, even on Linux which has tinyxml2 in apt at version 2.2.0. Long term we could make this vendor package provide a CMake module that can find and use the tinyxml2 that ships with Linux. Until now only Fast-RTPS uses tinyxml2 (I think). Because of the way the linking works out we don't run into an issue with Fast-RTPS using the system tinyxml2 and rviz using this vendored one, but we should consolidate them at some point. On macOS, since it has 5.0.1 install from Homebrew, the vendor package does nothing. Similarly on Windows since we have a custom choco package for tinxml2 at version 5.0.1, the vendor package does nothing. I could have made it just provide a CMake module that would work on Linux, but this was easier for me at the time. I'd rather merge this and open an issue to remove it in favor of something like a `tinyxml2_cmake_module` package, but I'm open to discussion on the point.

The pluginlib branch being added is the one I've been working on. It is based on the "remove_boost" branch (see: https://github.com/ros/pluginlib/pull/67) which in turn is based on the `melodic-devel` branch. It additionally has some changes to use ament and support ROS 2, as well as some fixes to the changes propose in the remove boost pr, see the diff with melodic:

https://github.com/ros/pluginlib/compare/melodic-devel...ros2

Permalink:

https://github.com/ros/pluginlib/compare/ad43b2b79deb9d5cd62792fa35d6bd7963c3fc36...244f065db2f110b15ec19b6ec797d28ea455d973