### PR TITLE
add resource retriever to the standard repos file

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -51,6 +51,10 @@ repositories:
     type: git
     url: https://github.com/ros/pluginlib.git
     version: ros2
+  ros/resource_retriever:
+    type: git
+    url: https://github.com/ros/resource_retriever.git
+    version: ros2
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git


### PR DESCRIPTION
This adds `resource_retriever`, again leading up to `rviz2` being added. It uses `libcurl`, and since we don't have that packaged on Windows yet I've added a vendor package for it in the `resource_retriever` repository. That should be temporary until we get it packaged everywhere. I believe I may need to extend our docker files to install the dev packages for curl on Linux, and I'll need to update the instructions on macOS to have it installed from Homebrew if that's not already happening.

This is a quick and dirty port, and so there are a lot of places to make improvements, I put several high level TODO's in the cmake, e.g.:

https://github.com/ros/resource_retriever/blob/3f18d8a229cad92734ac8970b62148fa0cced760/resource_retriever/CMakeLists.txt#L15

If you want to compare the difference in the ros2 branch I'm proposing here and it's ancestor `kinetic-devel` you can do it with this link:

https://github.com/ros/resource_retriever/compare/kinetic-devel...ros2

Permalink:

https://github.com/ros/resource_retriever/compare/0753a22ebc37516ff97f5bfe9d9946642165a6a7...3f18d8a229cad92734ac8970b62148fa0cced760

I might need to iterate on this since I haven't built it on Windows yet, but reviews can happen in the meantime if anyone is interested.