### PR TITLE
Ardent patch1

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -50,11 +50,11 @@ repositories:
   ros/pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: 2.0.0
+    version: 3.0.0
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
-    version: 2.0.0
+    version: 2.0.1
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
@@ -174,7 +174,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 2.0.0
+    version: 3.0.0
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -38,7 +38,7 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: 1f135d478dd9dcde98ed96c9aeef4f229e3a1450
+    version: bfb448e19bff253293e8f28ee8c3d3d78d882be2
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -55,6 +55,10 @@ repositories:
     type: git
     url: https://github.com/ros/resource_retriever.git
     version: 2.0.0
+  ros/ros_environment:
+    type: git
+    url: https://github.com/ros/ros_environment.git
+    version: 2.0.0
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -162,7 +162,7 @@ repositories:
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 0.4.0
+    version: 0.4.1
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git


### PR DESCRIPTION
The patch does the following for the upcoming patch release:

* Add `ros_environment` as a new package
* Use the latest hash of FastRTPS
  * While the [diff](https://github.com/eProsima/Fast-RTPS/compare/1f135d478dd9dcde98ed96c9aeef4f229e3a1450...bfb448e19bff253293e8f28ee8c3d3d78d882be2) isn't short it is the easiest way for us to get the fixes we need. All our tests are passing with `master` at the moment so I don't expect regressions. Therefore I would treat this as a "we sync with upstream of a third-party package" and expect they have done checking to avoid regressions.

Connect to ros2/ros2#454.