### PR TITLE
ardent: Bump resource_retriever to 2.0.2.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -54,7 +54,7 @@ repositories:
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
-    version: 2.0.1
+    version: 2.0.2
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git


### PR DESCRIPTION
resource_retriever 2.0.2 was released to address an issue with the debian packages. 

https://github.com/ros2/rosdistro/blob/edf2e849c9efd0553dbd41f91b0ccd1a169c2328/ardent/distribution.yaml#L508-L520

https://github.com/ros/resource_retriever/pull/19