### PR TITLE
use bouncy branch of ros_environment

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -58,7 +58,7 @@ repositories:
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: ardent
+    version: bouncy
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git


### PR DESCRIPTION
Based on this discussion: https://discourse.ros.org/t/ros-2-b-turtle-naming-brainstorming/3775

The `bouncy` branch has already been created in the [ros_environment](https://github.com/ros/ros_environment/commit/d4ff3812f296a3874dc1439c58f8cf8a88cea182) repo.