### PR TITLE
Revert "point to the branch with fixed namespaces pedning it being me…

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -38,7 +38,7 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: 15d49e9bb7f0bdb25532a936d05e072ec0cfe0b1
+    version: master
   ros/angles:
     type: git
     url: https://github.com/ros/angles.git


### PR DESCRIPTION
…rged upstream (#482)"

This reverts commit d851c903cbb28b71b64ce560701922c381f13b5b.
Now that Fast-RTPS merged the namespace escalation removal: https://github.com/ros2/rmw_fastrtps/pull/195#issuecomment-382005648

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4238)](http://ci.ros2.org/job/ci_linux/4238/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1274)](http://ci.ros2.org/job/ci_linux-aarch64/1274/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3505)](http://ci.ros2.org/job/ci_osx/3505/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4346)](http://ci.ros2.org/job/ci_windows/4346/)