### PR TITLE
remove ament_tools

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -15,10 +15,6 @@ repositories:
     type: git
     url: https://github.com/ament/ament_package.git
     version: master
-  ament/ament_tools:
-    type: git
-    url: https://github.com/ament/ament_tools.git
-    version: master
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git


### PR DESCRIPTION
With the switch to `colcon` in ros2/ci#132 we don't need these two repositories anymore in the workspace.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4285)](https://ci.ros2.org/job/ci_linux/4285/)