### PR TITLE
add navigation_msgs repository (for map_msgs package)

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -71,6 +71,10 @@ repositories:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
     version: ros2
+  ros-planning/navigation_msgs:
+    type: git
+    url: https://github.com/ros-planning/navigation_msgs.git
+    version: ros2
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git


### PR DESCRIPTION
`move_base_msgs` is disabled for now, since it only has Actions in it.

Connects to ros2/rviz#267