### PR TITLE
remove angles repo that's not necessary anymore

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -43,10 +43,6 @@ repositories:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
     version: master
-  ros/angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git


### PR DESCRIPTION
Dependency on angles was removed in https://github.com/ros-perception/laser_geometry/commit/c029efcdd633df8b4935897cabeb95e31abddc14#diff-34ae68f4adad56c25c5bc05dcb64794e

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4835)](http://ci.ros2.org/job/ci_linux/4835/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1689)](http://ci.ros2.org/job/ci_linux-aarch64/1689/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4014)](http://ci.ros2.org/job/ci_osx/4014/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4880)](http://ci.ros2.org/job/ci_windows/4880/)