### PR TITLE
Add crystal milestone and descriptions to labels

### DIFF
--- a/update_labels_github.py
+++ b/update_labels_github.py
@@ -7,22 +7,22 @@ from github import Github, GithubException, GithubObject
 github_api_url = 'https://api.github.com'
 
 
-# label_dict: name, color
+# label_dict: name, 2-tuple (color, description)
 LABEL_DICT = {
-    'bug': 'd73a4a',
+    'bug': ('d73a4a', "Something isn't working"),
     # 'hitlist': 'fc6b28',
-    'duplicate': 'cccccc',
-    'enhancement': 'a2eeef',
-    'question': 'd876e3',
-    'more-information-needed': '159818',
-    'help wanted': '008672',
+    'duplicate': ('cfd3d7', 'This issue or pull request already exists'),
+    'enhancement': ('a2eeef', 'New feature or request'),
+    'question': ('d876e3', 'Further information is requested'),
+    'more-information-needed': ('159818', 'Further information is required'),
+    'help wanted': ('008672', 'Extra attention is needed'),
     # 'claimed': '',
-    'wontfix': 'ffffff',
-    'ready': '80916d',
-    'in progress': 'fad8c7',
-    'in review': '388be2',
-    'invalid': 'e4e669',
-    'good first issue': '7057ff',
+    'wontfix': ('ffffff', 'This will not be worked on'),
+    'ready': ('80916d', 'Work is about to start (Kanban column)'),
+    'in progress': ('fad8c7', 'Actively being worked on (Kanban column)'),
+    'in review': ('388be2', 'Waiting for review (Kanban column)'),
+    'invalid': ('e4e669', "This doesn't seem right"),
+    'good first issue': ('7057ff', 'Good for newcomers'),
     # 'language/cmake': 'fbca04',
     # 'language/c': 'fbca04',
     # 'language/c++': 'fbca04',
@@ -45,23 +45,30 @@ def update_labels(commit, repo, label_dict):
     # print('  update label called with repo: %s and labels\n  %s' % (repo.name, label_dict))
     current_labels = [_ for _ in repo.get_labels()]
     current_labels_names = [_.name for _ in current_labels]
-    for label, color in label_dict.items():
+    for label, (color, description) in label_dict.items():
         # check if label with same name already exists
         if label in current_labels_names:
             idx = current_labels_names.index(label)
             # check if existing label has the right color
             current_label = current_labels[idx]
-            if current_label.color == color:
+            if current_label.color == color and current_label.description == description:
                 continue
-            print("  -> update color of '{0}' from '{1}' to '{2}'".format(
-                    label,
-                    current_label.color,
-                    color
-            ))
+            if current_label.color != color:
+                print("  -> update color of '{0}' from '{1}' to '{2}'".format(
+                        label,
+                        current_label.color,
+                        color
+                ))
+            if current_label.description != description:
+                print("  -> update description of '{0}' from '{1}' to '{2}'".format(
+                        label,
+                        current_label.description,
+                        description
+                ))
             if not commit:
                 continue
             try:
-                current_label.edit(label, color)
+                current_label.edit(label, color, description=description)
                 current_label.update()
             except GithubException as e:
                 if e.data['message'] == 'Repository was archived so is read-only.':
@@ -72,10 +79,11 @@ def update_labels(commit, repo, label_dict):
 
         else:
             # if label doesn't exist: create it
-            print("  -> creating label '%s' with color '%s'" % (label, color))
+            print("  -> creating label '%s' with color '%s' and description '%s'" % (
+                label, color, description))
             if not commit:
                 continue
-            repo.create_label(label, label_dict[label])
+            repo.create_label(label, color, description=description)
 
 
 def update_milestones(commit, repo, milestones_dict):
@@ -150,7 +158,7 @@ if __name__ == '__main__':
         '--label_dict',
         type=dict,
         default=LABEL_DICT,
-        help='dictionary of labels, label_name as key and color as value',)
+        help='dictionary of labels, label_name as key and [color, description] as value',)
     argparser.add_argument(
         '--milestones_dict',
         type=dict,

--- a/update_labels_github.py
+++ b/update_labels_github.py
@@ -37,6 +37,7 @@ REPO_BLACKLIST = [
 MILESTONES_DICT = {
     'untargeted': ['It is unlikely that the maintainers will have time to address these issues. Please provide pull requests if you want these issues to be addressed.', None],
     'bouncy': ['The ROS 2 release "Bouncy Bolson".', datetime.datetime(2018, 6, 22, 7, 0)],
+    'crystal': ['The ROS 2 release "Crystal Clemmys".', datetime.datetime(2018, 12, 31)],
 }
 
 


### PR DESCRIPTION
This adds a crystal milestone and label descriptions. I copied the descriptions for: `bug`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix` from the defaults on a new-ish github repo. I made up the descriptions for `more-information-needed`, `ready`, `in progress`, `in review`.

@dirk-thomas the script defaults to `ament` and `ros2` orgs. Would you like it applied to `colcon` as well? I suspect not since colcon isn't tied to the `crystal` release.