### PR TITLE
Add yaml_cpp_vendor

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -243,3 +243,7 @@ repositories:
     type: git
     url: https://github.com/ros2/urdfdom.git
     version: ros2
+  ros2/yaml_cpp_vendor:
+    type: git
+    url: https://github.com/ros2/yaml_cpp_vendor.git
+    version: master


### PR DESCRIPTION
This is split from the rviz repository to make depending on yaml_cpp easier for camera_calibration_parsers.