### PR TITLE
update cross-compilation assets

### DIFF
--- a/arm_crosscompilation/README.md
+++ b/arm_crosscompilation/README.md
@@ -1,1 +1,0 @@
-Documentation is in the wiki: https://github.com/ros2-for-arm/ros2/wiki/ROS2-on-arm-architecture


### PR DESCRIPTION
- Remove the arm_crosscompilation folder which is no longer used
- Add the new cross_compile repo.

We hosted the cross_compile repo under the **ros2-for-arm** organization to provide an example to help the review. But please don't merge this PR before **ros2/cross_compile** repo is created and we update this patch.

See documentation regarding the cross-compilation on the following PR https://github.com/ros2/ros2_documentation/pull/29