### PR TITLE
rc_logging repository was renamed to rcl_logging

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -119,9 +119,9 @@ repositories:
     type: git
     url: https://github.com/ros2/poco_vendor.git
     version: master
-  ros2/rc_logging:
+  ros2/rcl_logging:
     type: git
-    url: https://github.com/ros2/rc_logging.git
+    url: https://github.com/ros2/rcl_logging.git
     version: master
   ros2/rcl:
     type: git


### PR DESCRIPTION
See: https://github.com/ros2/rc_logging/pull/2