### PR TITLE
add rqt repos

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -67,6 +67,18 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
     version: ros2
+  ros-visualization/python_qt_binding:
+    type: git
+    url: https://github.com/ros-visualization/python_qt_binding.git
+    version: crystal-devel
+  ros-visualization/qt_gui_core:
+    type: git
+    url: https://github.com/ros-visualization/qt_gui_core.git
+    version: crystal-devel
+  ros-visualization/rqt:
+    type: git
+    url: https://github.com/ros-visualization/rqt.git
+    version: crystal-devel
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git


### PR DESCRIPTION
Add `rqt` repositories:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5874)](http://ci.ros2.org/job/ci_linux/5874/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2429)](http://ci.ros2.org/job/ci_linux-aarch64/2429/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4862)](http://ci.ros2.org/job/ci_osx/4862/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5765)](http://ci.ros2.org/job/ci_windows/5765/)
  * needs PyQt5 on the Windows nodes