### PR TITLE
add rqt plugins already released

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -79,6 +79,42 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/rqt.git
     version: crystal-devel
+  ros-visualization/rqt_console:
+    type: git
+    url: https://github.com/ros-visualization/rqt_console.git
+    version: crystal-devel
+  ros-visualization/rqt_msg:
+    type: git
+    url: https://github.com/ros-visualization/rqt_msg.git
+    version: crystal-devel
+  ros-visualization/rqt_plot:
+    type: git
+    url: https://github.com/ros-visualization/rqt_plot.git
+    version: crystal-devel
+  ros-visualization/rqt_publisher:
+    type: git
+    url: https://github.com/ros-visualization/rqt_publisher.git
+    version: crystal-devel
+  ros-visualization/rqt_py_console:
+    type: git
+    url: https://github.com/ros-visualization/rqt_py_console.git
+    version: crystal-devel
+  ros-visualization/rqt_service_caller:
+    type: git
+    url: https://github.com/ros-visualization/rqt_service_caller.git
+    version: crystal-devel
+  ros-visualization/rqt_shell:
+    type: git
+    url: https://github.com/ros-visualization/rqt_shell.git
+    version: crystal-devel
+  ros-visualization/rqt_srv:
+    type: git
+    url: https://github.com/ros-visualization/rqt_srv.git
+    version: crystal-devel
+  ros-visualization/rqt_top:
+    type: git
+    url: https://github.com/ros-visualization/rqt_top.git
+    version: crystal-devel
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git


### PR DESCRIPTION
Follow up of #619.

`rqt_image_view` isn't included since its dependencies `image_common` and `vision_opencv` are not in the repos file atm.

* Linux Bionic: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=158)](https://ci.ros2.org/job/ci_packaging_linux/158/)
* Linux Xenial: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=159)](https://ci.ros2.org/job/ci_packaging_linux/159/)
* Linux aarch64: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=42)](https://ci.ros2.org/job/ci_packaging_linux-aarch64/42/)
* macOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_osx&build=60)](https://ci.ros2.org/job/ci_packaging_osx/60/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=86)](https://ci.ros2.org/job/ci_packaging_windows/86/)

@mlautman FYI