### PR TITLE
insert osrf_pycommon inside osrf folder

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -19,10 +19,6 @@ repositories:
     type: git
     url: https://github.com/ament/googletest.git
     version: ros2
-  ament/osrf_pycommon:
-    type: git
-    url: https://github.com/osrf/osrf_pycommon.git
-    version: master
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
@@ -34,6 +30,10 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
+    version: master
+  osrf/osrf_pycommon:
+    type: git
+    url: https://github.com/osrf/osrf_pycommon.git
     version: master
   osrf/osrf_testing_tools_cpp:
     type: git


### PR DESCRIPTION
actually osrf_pycommon is set inside the ament folder, but the correct organization is osrf.