### PR TITLE
Add tinydir_vendor to ros2.repos

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -275,6 +275,10 @@ repositories:
     type: git
     url: https://github.com/ros2/system_tests.git
     version: master
+  ros2/tinydir_vendor:
+    type: git
+    url: https://github.com/ros2/tinydir_vendor.git
+    version: master
   ros2/tinyxml_vendor:
     type: git
     url: https://github.com/ros2/tinyxml_vendor.git


### PR DESCRIPTION
Pending transfer of https://github.com/aws-robotics/vendored-tinydir to `ros2` org, see https://github.com/ros/rosdistro/pull/19921#discussion_r248102149