### PR TITLE
Pin FastRTPS pre eProsima/Fast-RTPS/pull/411

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: master
+    version: bc61fa3fab63ced48416db86ebb8df4e0f0cebdf
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Upstream changes are causing test failures (ros2/build_cop#166). This pins it temporarily until the problem is resolved.