### PR TITLE
Add ros2/test_interface_files

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -283,6 +283,10 @@ repositories:
     type: git
     url: https://github.com/ros2/system_tests.git
     version: master
+  ros2/test_interface_files
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: master
   ros2/tinydir_vendor:
     type: git
     url: https://github.com/ros2/tinydir_vendor.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -283,7 +283,7 @@ repositories:
     type: git
     url: https://github.com/ros2/system_tests.git
     version: master
-  ros2/test_interface_files
+  ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
     version: master


### PR DESCRIPTION
Connects to ros2/rcl_interfaces#58

This repository contains the interface files used for testing in several packages.