### PR TITLE
Adding rosbag2

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -239,6 +239,14 @@ repositories:
     type: git
     url: https://github.com/ros2/ros2cli.git
     version: master
+  ros2/rosbag2:
+    type: git
+    url: https://github.com/ros2/rosbag2.git
+    version: master
+  ros2/rosbag2_bag_v2:
+    type: git
+    url: https://github.com/ros2/rosbag2_bag_v2.git
+    version: master
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -243,10 +243,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rosbag2.git
     version: master
-  ros2/rosbag2_bag_v2:
-    type: git
-    url: https://github.com/ros2/rosbag2_bag_v2.git
-    version: master
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git


### PR DESCRIPTION
connected to ros2/rosbag2#111

Adding the rosbag2 to the official ros2 repos file.
Current CI running here:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6805)](http://ci.ros2.org/job/ci_linux/6805/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3101)](http://ci.ros2.org/job/ci_linux-aarch64/3101/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5596)](http://ci.ros2.org/job/ci_osx/5596/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6630)](http://ci.ros2.org/job/ci_windows/6630/)