### PR TITLE
Add rostest repository to ros2.repos file

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -275,6 +275,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_opensplice.git
     version: master
+  ros2/rostest:
+    type: git
+    url: https://github.com/ros2/rostest.git
+    version: master
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -231,6 +231,10 @@ repositories:
     type: git
     url: https://github.com/ros2/robot_state_publisher.git
     version: ros2
+  ros2/ros_testing:
+    type: git
+    url: https://github.com/ros2/ros_testing.git
+    version: master
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git
@@ -274,10 +278,6 @@ repositories:
   ros2/rosidl_typesupport_opensplice:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_opensplice.git
-    version: master
-  ros2/rostest:
-    type: git
-    url: https://github.com/ros2/rostest.git
     version: master
   ros2/rviz:
     type: git


### PR DESCRIPTION
Exactly what the title says. Connected to https://github.com/ros2/launch/issues/208. 