### PR TITLE
Dashing Patch Release 2

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.7.3
+    version: 0.7.6
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -54,7 +54,7 @@ repositories:
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: 1.0.5
+    version: 1.0.6
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
@@ -74,7 +74,7 @@ repositories:
   ros-visualization/rqt_plot:
     type: git
     url: https://github.com/ros-visualization/rqt_plot.git
-    version: 1.0.5
+    version: 1.0.6
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
@@ -102,11 +102,11 @@ repositories:
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
-    version: 1.3.1
+    version: 1.3.2
   ros/pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: 2.3.1
+    version: 2.3.2
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
@@ -138,7 +138,7 @@ repositories:
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: 0.7.3
+    version: 0.7.4
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
@@ -146,7 +146,7 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.11.3
+    version: 0.11.4
   ros2/kdl_parser:
     type: git
     url: https://github.com/ros2/kdl_parser.git
@@ -158,7 +158,7 @@ repositories:
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.8.4
+    version: 0.8.5
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -178,7 +178,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 0.7.5
+    version: 0.7.6
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -194,15 +194,15 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 0.7.6
+    version: 0.7.7
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 0.7.4
+    version: 0.7.5
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 0.1.0
+    version: 0.1.1
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
@@ -222,7 +222,7 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 0.7.4
+    version: 0.7.5
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
@@ -230,7 +230,7 @@ repositories:
   ros2/rmw_opensplice:
     type: git
     url: https://github.com/ros2/rmw_opensplice.git
-    version: 0.7.2
+    version: 0.7.3
   ros2/robot_state_publisher:
     type: git
     url: https://github.com/ros2/robot_state_publisher.git
@@ -242,7 +242,7 @@ repositories:
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git
-    version: 0.7.2
+    version: 0.7.3
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
@@ -250,11 +250,11 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.1.3
+    version: 0.1.4
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 0.7.4
+    version: 0.7.5
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
@@ -282,11 +282,11 @@ repositories:
   ros2/rosidl_typesupport_opensplice:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_opensplice.git
-    version: 0.7.1
+    version: 0.7.2
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 6.1.2
+    version: 6.1.3
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
@@ -294,7 +294,7 @@ repositories:
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git
-    version: 0.7.1
+    version: 0.7.2
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git


### PR DESCRIPTION
Update the dashing-release repos file for patch release 2. The merged commit will also be tagged as `release-dashing-20190806`.

Closes #736 