### PR TITLE
Add eigen3_cmake_module

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -135,6 +135,10 @@ repositories:
     type: git
     url: https://github.com/ros2/demos.git
     version: master
+  ros2/eigen3_cmake_module:
+    type: git
+    url: https://github.com/ros2/eigen3_cmake_module.git
+    version: master
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git


### PR DESCRIPTION
Adds the `eigen3_cmake_module` repository.

Requires ros2/eigen3_cmake_module#3