### PR TITLE
identify master as eloquent

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -118,7 +118,7 @@ repositories:
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: dashing
+    version: eloquent
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Using the new `eloquent` branch: https://github.com/ros/ros_environment/tree/eloquent