### PR TITLE
Add ifcfg_vendor to ros2 repos

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -162,7 +162,7 @@ repositories:
   ros2/ifcfg_vendor:
     type: git
     url: https://github.com/ros2/ifcfg_vendor
-    version: ros2
+    version: master
   ros2/kdl_parser:
     type: git
     url: https://github.com/ros2/kdl_parser.git


### PR DESCRIPTION
ifcfg_vendor is used in ros2doctor CLI network feature https://github.com/ros2/ros2cli/pull/319 