### PR TITLE
Add eigen3_cmake_module to dashing branch.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -135,6 +135,10 @@ repositories:
     type: git
     url: https://github.com/ros2/demos.git
     version: dashing
+  ros2/eigen3_cmake_module:
+    type: git
+    url: https://github.com/ros2/eigen3_cmake_module.git
+    version: master
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git


### PR DESCRIPTION
Add `ros2/eigen3_cmake_module` to `dashing` repos file

Should fix https://github.com/ros2/rosidl/pull/407#issuecomment-528561286 which is using `ros2.repos` from the `dashing` branch.