### PR TITLE
[Dashing] Updating Fast-RTPS and Fast-CDR to tags

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -26,11 +26,11 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: 906c966c426f85d503baca9c2e46bead7b633dff
+    version: v1.0.11
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: fda2376460cffe987432162140494f2ddd8d68cd
+    version: v1.8.2
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Updating Fast-CDR to v1.0.11 will include two important fixes:
* Fix warnings and tests for 32-bit ARM (eProsima/Fast-CDR#53)
* Resize sequences on deserialize (eProsima/Fast-CDR#59)

Updating Fast-RTPS to v1.8.2 will include fixes for:
* Interoperability issues on liveliness protocol (eProsima/Fast-RTPS/#742)
* Standard compliance on KEEP_LAST (eProsima/Fast-RTPS#731)
* Additional fixes to the Wifi multicast issue (eProsima/Fast-RTPS#745)