### PR TITLE
Update ros2_tracing to 0.2.9

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -38,7 +38,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 0.2.8
+    version: 0.2.9
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>

Contains fix for Windows. See https://github.com/ros2/rclcpp/pull/789#issuecomment-543726539