### PR TITLE
Pin Fast-RTPS and Fast-CDR before releasing Eloquent 

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -26,11 +26,11 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: master
+    version: v1.0.11
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: master
+    version: v1.9.2
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
I propose temporally pinning both, to decouple from their changes.
Particularly, there are a lot of changes going on in `Fast-RTPS` and cross-vendor tests started failing.

Pin Fast-RTPS to v1.9.2
Pin Fast-CDR to v1.0.11