### PR TITLE
Switch branch for rqt_console to dashing-devel.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -74,7 +74,7 @@ repositories:
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: crystal-devel
+    version: dashing-devel
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git


### PR DESCRIPTION
crystal-devel doesn't work with master.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>