### PR TITLE
move CycloneDDS repos into ros2.repos file

### DIFF
--- a/cyclonedds.repos
+++ b/cyclonedds.repos
@@ -1,9 +1,0 @@
-repositories:
-  eclipse-cyclonedds/cyclonedds:
-    type: git
-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: master
-  ros2/rmw_cyclonedds:
-    type: git
-    url: https://github.com/ros2/rmw_cyclonedds.git
-    version: master

--- a/ros2.repos
+++ b/ros2.repos
@@ -23,6 +23,10 @@ repositories:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
     version: master
+  eclipse-cyclonedds/cyclonedds:
+    type: git
+    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+    version: master
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
@@ -250,6 +254,10 @@ repositories:
   ros2/rmw_connext:
     type: git
     url: https://github.com/ros2/rmw_connext.git
+    version: master
+  ros2/rmw_cyclonedds:
+    type: git
+    url: https://github.com/ros2/rmw_cyclonedds.git
     version: master
   ros2/rmw_fastrtps:
     type: git


### PR DESCRIPTION
WIth CycloneDDS having the same Tier level as OpenSplice and ros2/ci#340 there is no need for a separate `.repos` file anymore.