### PR TITLE
Remove rclc and ros2/tutorials.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -219,10 +219,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rcl_logging.git
     version: master
-#  ros2/rclc:
-#    type: git
-#    url: https://github.com/ros2/rclc.git
-#    version: master
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
@@ -351,10 +347,6 @@ repositories:
     type: git
     url: https://github.com/ros2/tlsf.git
     version: master
-#  ros2/tutorials:
-#    type: git
-#    url: https://github.com/ros2/tutorials.git
-#    version: master
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git


### PR DESCRIPTION
They've been disabled for literally years now; I think it is
safe to say we aren't actively working on them.  If we want
to resurrect them in the future, we can always add them back.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>