### PR TITLE
Add cyclonedd and tutorials repositories.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -191,10 +191,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rcl_logging.git
     version: 0.2.1
-#  ros2/rclc:
-#    type: git
-#    url: https://github.com/ros2/rclc.git
-#    version: master
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
@@ -319,10 +315,6 @@ repositories:
     type: git
     url: https://github.com/ros2/tlsf.git
     version: 0.5.0
-#  ros2/tutorials:
-#    type: git
-#    url: https://github.com/ros2/tutorials.git
-#    version: master
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 1c8c2944ff60544da38fefda5b4e80270e7fec48
+    version: 76fa68808682a15dd8aff26da20622ac574fa1a1
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
@@ -230,7 +230,7 @@ repositories:
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: 888235e96edfa9ca49a5e074407a98ed72843e65
+    version: 0.4.1
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -230,7 +230,7 @@ repositories:
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: 0.4.1
+    version: 0.4.2
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -119,6 +119,10 @@ repositories:
     type: git
     url: https://github.com/ros/ros_environment.git
     version: 2.3.0
+  ros/ros_tutorials:
+    type: git
+    url: https://github.com/ros/ros_tutorials.git
+    version: 1.0.1
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -31,6 +31,10 @@ repositories:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
     version: v1.8.2
+  eclipse-cyclonedds/cyclonedds:
+    type: git
+    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+    version: 1c8c2944ff60544da38fefda5b4e80270e7fec48
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
@@ -219,6 +223,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_connext.git
     version: 0.7.3
+  ros2/rmw_cyclonedds:
+    type: git
+    url: https://github.com/ros2/rmw_cyclonedds.git
+    version: 888235e96edfa9ca49a5e074407a98ed72843e65
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git


### PR DESCRIPTION
These were added to the Dashing development branch during the previous patch release cycle but didn't make it to the release repositories file. Also drops the commented out repos as in #810.