### PR TITLE
Update ros2_tracing to 0.2.10 for new intra-process comms

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 0.2.9
+    version: 0.2.10
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>

This new version has the changes needed for the fix to support the new intra-process communications for https://github.com/ros2/rclcpp/pull/918