### PR TITLE
Update ros2_tracing to 0.2.11 after ament registration fix

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 0.2.10
+    version: 0.2.11
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
See `ros2_tracing` issue: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/issues/60

This new version also contains some other minor fixes.

rosdistro PR: https://github.com/ros/rosdistro/pull/23257

FYI @dirk-thomas