### PR TITLE
Update ros2_tracing to 0.2.12

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: master
+    version: 0.2.12
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 0.2.10
+    version: master
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Getting ahead of releasing a new version to address fixes in CI. There
are other changes to be tested as well however.

Before this is merged, we should update the PR to use the release tag once it is made.