### PR TITLE
Pin Fast-RTPS to the last version known to interoperate with Connext.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: 1.9.x
+    version: c7b6d9361c48e61d2c7117ef3fbc44812b1b6139
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
This should workaround the interoperability problems we are
seeing in test_communication between Fast-RTPS and Connext.
We'll want to try out a full fix from eProsima once it is
available.

Signed-off-by: Chris Lalancette <clalancette@gmail.com>

Works around https://github.com/ros2/build_cop/issues/264

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9341)](http://ci.ros2.org/job/ci_linux/9341/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5024)](http://ci.ros2.org/job/ci_linux-aarch64/5024/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7647)](http://ci.ros2.org/job/ci_osx/7647/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9260)](http://ci.ros2.org/job/ci_windows/9260/)
* Windows-container [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=129)](http://ci.ros2.org/job/ci_windows-container/129/)