### PR TITLE
Update ros2_tracing to 0.3.0 for Foxy

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 0.2.12
+    version: 0.3.0
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Includes various improvements, including a fix for `cppcheck` on Focal (also see https://github.com/ros2/rclcpp/pull/1000).

cc @brawner