### PR TITLE
Add image common to repos file

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -55,6 +55,10 @@ repositories:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
     version: ros2
+  ros-perception/image_common:
+    type: git
+    url: https://github.com/ros-perception/image_common.git
+    version: ros2
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git


### PR DESCRIPTION
It would be nice to allow rviz2 to also visualize compressed images just as in ros1.
To do this, we'd need the ported image_transport.

See corresponding PR in RViz:  https://github.com/ros2/rviz/pull/523