### PR TITLE
removed poco_vendor from repos file

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -211,10 +211,6 @@ repositories:
     type: git
     url: https://github.com/ros2/orocos_kinematics_dynamics.git
     version: ros2
-  ros2/poco_vendor:
-    type: git
-    url: https://github.com/ros2/poco_vendor.git
-    version: master
   ros2/python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git


### PR DESCRIPTION
Related with "Included utils to load, unload and get symbols from shared libraries" https://github.com/ros2/rcutils/issues/216

Signed-off-by: ahcorde <ahcorde@gmail.com>