### PR TITLE
[Eloquent] Pin foonathan_memory_vendor to a specific version

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -26,7 +26,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 08d9c296f1b569c18188528fd5e8f086e94dd67d 
+    version: 08d9c296f1b569c18188528fd5e8f086e94dd67d
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
@@ -37,7 +37,7 @@ repositories:
     version: ros2-eloquent
   eProsima/foonathan_memory_vendor:
     type: git
-    url: https://github.com/eProsima/foonathan_memory_vendor.git
+    url: https://github.com/mjcarroll/foonathan_memory_vendor.git
     version: master
   micro-ROS/ros_tracing/ros2_tracing:
     type: git


### PR DESCRIPTION
Attempt to fix recent regression in Eloquent Nightly CI: https://github.com/ros2/build_farmer/issues/270