### PR TITLE
Add topic statistics dependency

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -59,6 +59,10 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
     version: ros2
+  ros-tooling/metrics_statistics_msgs:
+    type: git
+    url: https://github.com/ros-tooling/metrics_statistics_msgs.git
+    version: master
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -59,9 +59,9 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
     version: ros2
-  ros-tooling/metrics_statistics_msgs:
+  ros-tooling/libstatistics_collector:
     type: git
-    url: https://github.com/ros-tooling/metrics_statistics_msgs.git
+    url: https://github.com/ros-tooling/libstatistics_collector.git
     version: master
   ros-visualization/interactive_markers:
     type: git


### PR DESCRIPTION
Add remaining dependency of topic statistics to ros2.repos.

This is blocked on
* [x] ~~https://github.com/ros2/ros2/pull/896~~ https://github.com/ros2/rcl_interfaces/pull/98
* [ ] https://github.com/ros-tooling/aws-roadmap/issues/248
* [x] https://github.com/ros-tooling/aws-roadmap/issues/249