### PR TITLE
Bump to the latest commit on ros2_tracing to fix deprecation.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 0.3.0
+    version: c3ea84b4b98a99d0a7ba3ed94846e1aaec8a8d13
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Since the release of ros2_tracing including this change is delayed we'll
temporarily pin the commit which addresses the deprecation warning.

There are a substantial number of changes since the last release ([0.3.0...master](https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/compare/0.3.0...master)) so this may not go down easy.

This PR "causes" #898 which will be resolved when we're back on a release channel.

Signed-off-by: Steven! Ragnarök <steven@nuclearsandwich.com>