### PR TITLE
Update ros_tutorials branch for Foxy

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -150,7 +150,7 @@ repositories:
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: eloquent-devel
+    version: foxy-devel
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Since https://github.com/ros/ros_tutorials/pull/84, we have diverged from Eloquent
and created a new branch foxy-devel.

Only building `turtlesim` since it's the only package affected by this change:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10263)](http://ci.ros2.org/job/ci_linux/10263/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5801)](http://ci.ros2.org/job/ci_linux-aarch64/5801/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8344)](http://ci.ros2.org/job/ci_osx/8344/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10151)](https://ci.ros2.org/job/ci_windows/10151/)