### PR TITLE
switch to Fast-RTPS 2.0.x

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: 1.10.x
+    version: 2.0.x
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
Full CI builds with only Fast-RTPS:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10407)](http://ci.ros2.org/job/ci_linux/10407/)
  * Unrelated CMake warning
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5915)](http://ci.ros2.org/job/ci_linux-aarch64/5915/)
  * Unrelated CMake warning
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8487)](http://ci.ros2.org/job/ci_osx/8487/)
  * Unrelated CMake warning
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10361)](http://ci.ros2.org/job/ci_windows/10361/)
  * Unrelated compiler warnings
  * 112 test failures, some might be "expected" if they happened with 1.10.x already, but certainly not all