### PR TITLE
Dashing: set cyclonedds to releases/0.5.x

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -26,7 +26,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: master
+    version: releases/0.5.x
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git


### PR DESCRIPTION
Triggered by https://github.com/ros2/ros2/pull/905#issuecomment-617923445, this is a followup to 585490701109d6768a33c667b2607c57e29c4744 to complete the change
in versioning strategy https://github.com/ros2/rmw_cyclonedds/pull/142

Signed-off-by: Erik Boasson <eb@ilities.com>