### PR TITLE
Update ros2_tracing to 1.0.0

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: c3ea84b4b98a99d0a7ba3ed94846e1aaec8a8d13
+    version: 1.0.0
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Closes #898 

Released: https://github.com/ros/rosdistro/pull/24573