### PR TITLE
Revert "switch to Fast-RTPS 2.0.x (#906)"

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git
-    version: 2.0.x
+    version: 1.10.x
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
Reverts #906.

Nightlies have hundreds of cross-vendor tests failing (e.g.: https://ci.ros2.org/view/nightly/job/nightly_linux_release/1526/), and that makes the job to FAIL.

I've triggered a full CI job to validate:

- Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6003)](http://ci.ros2.org/job/ci_linux-aarch64/6003/)