### PR TITLE
Use HTTPS for rpyutils URL

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -325,7 +325,7 @@ repositories:
     version: master
   ros2/rpyutils:
     type: git
-    url: http://github.com/ros2/rpyutils.git
+    url: https://github.com/ros2/rpyutils.git
     version: master
   ros2/rviz:
     type: git


### PR DESCRIPTION
Noticed this when I ran

```shell
$ vcs import src/ < ros2/ros2.repos
...
=== src/ros2/rpyutils (git) ===
Cloning into '.'...
warning: redirecting to https://github.com/ros2/rpyutils.git/
Already on 'master'
Your branch is up to date with 'origin/master'.
...
```

Took me some time to notice the missing `s`!