### PR TITLE
Update ros2_tracing to 1.0.1

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 1.0.0
+    version: 1.0.1
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Contains some minor fixes.

See: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/compare/1.0.0...1.0.1