### PR TITLE
Added tango_icons_vendor

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -75,6 +75,10 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
     version: foxy-devel
+  ros-visualization/qt_gui_icons:
+    type: git
+    url: https://github.com/ros-visualization/qt_gui_icons.git
+    version: master
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -75,9 +75,9 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
     version: foxy-devel
-  ros-visualization/qt_gui_icons:
+  ros-visualization/tango_icons_vendor:
     type: git
-    url: https://github.com/ros-visualization/qt_gui_icons.git
+    url: https://github.com/ros-visualization/tango_icons_vendor.git
     version: master
   ros-visualization/rqt:
     type: git

--- a/ros2.repos
+++ b/ros2.repos
@@ -75,10 +75,6 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
     version: foxy-devel
-  ros-visualization/tango_icons_vendor:
-    type: git
-    url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: master
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
@@ -135,6 +131,10 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
     version: dashing-devel
+  ros-visualization/tango_icons_vendor:
+    type: git
+    url: https://github.com/ros-visualization/tango_icons_vendor.git
+    version: master
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git


### PR DESCRIPTION
Icons are not being shown on Windows and in MacOS (on MacOS are shown if you have installed the brew bottle ros/deps/tango-icon-theme). On Windows there is no change to install this package. 

I have include by default the installation on MacOS these icons https://github.com/ros-visualization/qt_gui_icons/pull/1 and I have update the logic to load these icons when there is no icon theme load in Qt https://github.com/ros-visualization/qt_gui_core/pull/222

Signed-off-by: ahcorde <ahcorde@gmail.com>