### PR TITLE
Update ros2_tracing for Foxy

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 1.0.1
+    version: 1.0.2
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
For backported fix related to https://github.com/ros2/ros2/issues/951

See https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/merge_requests/186

Release: https://github.com/ros/rosdistro/pull/25593