### PR TITLE
Move the ros2_tracing tag to 0.2.12.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 0.2.10
+    version: 0.2.12
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
This is what was released in the last eloquent-release branch,
so it should be at least that on the eloquent branch.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>