### PR TITLE
Switch to tracking master branch of ros2_tracing instead of release tag

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -46,7 +46,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 1.0.1
+    version: master
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
See #957