### PR TITLE
Foxy release versions 2020-07-10

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 0.9.5
+    version: 0.9.6
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -10,11 +10,11 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.9.4
+    version: 0.9.5
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.9.1
+    version: 0.9.2
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
@@ -33,7 +33,7 @@ repositories:
     version: v1.0.13
   eProsima/Fast-RTPS:
     type: git
-    url: https://github.com/eProsima/Fast-RTPS.git
+    url: https://github.com/eProsima/Fast-DDS.git
     version: v2.0.0
   eProsima/foonathan_memory_vendor:
     type: git
@@ -66,7 +66,7 @@ repositories:
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
-    version: 2.1.1
+    version: 2.1.2
   ros-visualization/python_qt_binding:
     type: git
     url: https://github.com/ros-visualization/python_qt_binding.git
@@ -102,7 +102,7 @@ repositories:
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
-    version: 1.0.5
+    version: 1.1.0
   ros-visualization/rqt_py_console:
     type: git
     url: https://github.com/ros-visualization/rqt_py_console.git
@@ -154,7 +154,7 @@ repositories:
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: 1.2.2
+    version: 1.2.4
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
@@ -186,7 +186,7 @@ repositories:
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: 0.9.2
+    version: 0.9.3
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
@@ -222,7 +222,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 1.1.5
+    version: 1.1.6
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -234,15 +234,15 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 2.0.0
+    version: 2.0.2
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 1.0.2
+    version: 1.0.4
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 1.0.1
+    version: 1.1.0
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
@@ -258,11 +258,11 @@ repositories:
   ros2/rmw_connext:
     type: git
     url: https://github.com/ros2/rmw_connext.git
-    version: 1.0.0
+    version: 1.0.1
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: 0.7.1
+    version: 0.7.2
   ros2/rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
@@ -270,7 +270,7 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 1.0.1
+    version: 1.0.2
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
@@ -278,11 +278,11 @@ repositories:
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git
-    version: 0.9.2
+    version: 0.9.3
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.9.5
+    version: 0.9.7
   ros2/ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git
@@ -290,7 +290,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.3.2
+    version: 0.3.3
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -330,7 +330,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 8.1.1
+    version: 8.2.0
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -338,11 +338,11 @@ repositories:
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: 0.9.1
+    version: 0.9.2
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git
-    version: 0.9.0
+    version: 0.9.1
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git


### PR DESCRIPTION
Updated versions for Foxy Patch Release 1.

### CI

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11415)](https://ci.ros2.org/job/ci_linux/11415/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6626)](http://ci.ros2.org/job/ci_linux-aarch64/6626/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9352)](http://ci.ros2.org/job/ci_osx/9352/)
  * 4 test failures
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11311)](http://ci.ros2.org/job/ci_windows/11311/)
  * 3 test failures

### Packaging

* Linux: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_linux&build=1928)](https://ci.ros2.org/view/packaging/job/packaging_linux/1928/)
* Linux-aarch64: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_linux-aarch64&build=1287)](https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/1287/)
* macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_osx&build=1916)](https://ci.ros2.org/view/packaging/job/packaging_osx/1916/)
* Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_windows&build=1799)](https://ci.ros2.org/view/packaging/job/packaging_windows/1799/)
* Windows Debug: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_windows_debug&build=750)](https://ci.ros2.org/view/packaging/job/packaging_windows_debug/750/)
* CentOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_linux-centos&build=470)](https://ci.ros2.org/view/packaging/job/packaging_linux-centos/470/)
