### PR TITLE
Add ros2cli_common_extensions metapackage

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -287,6 +287,10 @@ repositories:
     type: git
     url: https://github.com/ros2/ros2cli.git
     version: master
+  ros2/ros2cli_common_extensions:
+    type: git
+    url: https://github.com/ros2/ros2cli_common_extensions.git
+    version: master
   ros2/ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git


### PR DESCRIPTION
Adding the new https://github.com/ros2/ros2cli_common_extensions.