### PR TITLE
[foxy] Add ros2cli common extensions metapackage

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -283,6 +283,10 @@ repositories:
     type: git
     url: https://github.com/ros2/ros2cli.git
     version: foxy
+  ros2/ros2cli_common_extensions:
+    type: git
+    url: https://github.com/ros2/ros2cli_common_extensions.git
+    version: foxy
   ros2/ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git


### PR DESCRIPTION
Similar to https://github.com/ros2/ros2/pull/976 but for Foxy.

It will allow people doing from source development to build all command line tools like:
```
colcon build --packages-up-to ros2cli_common_extensions
```

I've also made a release of this package into Foxy: https://github.com/ros/rosdistro/pull/25804