### PR TITLE
Update branch for rqt_graph

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -94,7 +94,7 @@ repositories:
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: crystal-devel
+    version: dashing-devel
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git


### PR DESCRIPTION
The dashing-devel branch was created since https://github.com/ros-visualization/rqt_graph/pull/49

@dirk-thomas let me know if you'd like to backport the recent changes on `dashing-devel` to other distros and I can open similar PRs for them as well. I think it would be nice to backport to at least Foxy so that `ros2 run` works on Windows. This will set a precedent for similar patches to other rqt packages.