### PR TITLE
Add pybind11_vendor

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -231,6 +231,10 @@ repositories:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
     version: main
+  ros2/pybind11_vendor:
+    type: git
+    url: https://github.com/ros2/pybind11_vendor.git
+    version: master
   ros2/python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git


### PR DESCRIPTION
Pending merge of https://github.com/ros2/pybind11_vendor/pull/2
Needed for rosbag2 Python API https://github.com/ros2/rosbag2/pull/308