### PR TITLE
Foxy release versions 2020-08-07

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -193,7 +193,7 @@ repositories:
     version: 0.13.5
   ros2/kdl_parser:
     type: git
-    url: https://github.com/ros2/kdl_parser.git
+    url: https://github.com/ros/kdl_parser.git
     version: 2.4.1
   ros2/launch:
     type: git

--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.0.0
+    version: v2.0.1
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 1.0.1
+    version: 1.0.2
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
@@ -74,7 +74,7 @@ repositories:
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: 1.1.0
+    version: 1.1.1
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
@@ -110,7 +110,7 @@ repositories:
   ros-visualization/rqt_reconfigure:
     type: git
     url: https://github.com/ros-visualization/rqt_reconfigure.git
-    version: 1.0.5
+    version: 1.0.6
   ros-visualization/rqt_service_caller:
     type: git
     url: https://github.com/ros-visualization/rqt_service_caller.git
@@ -154,7 +154,7 @@ repositories:
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: 1.2.4
+    version: 1.2.5
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
@@ -166,11 +166,11 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 2.0.1
+    version: 2.0.3
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
-    version: 1.2.1
+    version: 1.2.2
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
@@ -190,7 +190,7 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.13.4
+    version: 0.13.5
   ros2/kdl_parser:
     type: git
     url: https://github.com/ros2/kdl_parser.git
@@ -222,7 +222,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 1.1.6
+    version: 1.1.7
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -230,11 +230,11 @@ repositories:
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: 1.0.0
+    version: 1.0.1
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 2.0.2
+    version: 2.1.0
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
@@ -242,7 +242,7 @@ repositories:
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 1.1.0
+    version: 1.3.0
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
@@ -262,7 +262,7 @@ repositories:
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: 0.7.2
+    version: 0.7.3
   ros2/rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
@@ -270,7 +270,7 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 1.0.2
+    version: 1.2.0
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
@@ -290,7 +290,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.3.3
+    version: 0.3.4
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -194,7 +194,7 @@ repositories:
   ros2/kdl_parser:
     type: git
     url: https://github.com/ros2/kdl_parser.git
-    version: 2.4.0
+    version: 2.4.1
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git


### PR DESCRIPTION
Updated version for Foxy Patch Release 2

### CI

Builds are failing due to an infrastructure issue, but the code was built and tests completed.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11797)](http://ci.ros2.org/job/ci_linux/11797/)
  * 1 test failure (sros2 mypy, fixed in https://github.com/ros2/sros2/pull/232)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6880)](http://ci.ros2.org/job/ci_linux-aarch64/6880/)
  * 1 test failure (sros2 mypy, fixed in https://github.com/ros2/sros2/pull/232)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9634)](http://ci.ros2.org/job/ci_osx/9634/)
  * 3 test failures
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11741)](http://ci.ros2.org/job/ci_windows/11741/)
  * 3 test failures

### Packaging

* Linux: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_linux&build=1974)](https://ci.ros2.org/view/packaging/job/packaging_linux/1974/)
* Linux-aarch64: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_linux-aarch64&build=1329)](https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/1329/)
* macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_osx&build=1948)](https://ci.ros2.org/view/packaging/job/packaging_osx/1948/)
* Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_windows&build=1835)](https://ci.ros2.org/view/packaging/job/packaging_windows/1835/)
* Windows Debug: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_windows_debug&build=786)](https://ci.ros2.org/view/packaging/job/packaging_windows_debug/786/)
* CentOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_linux-centos&build=506)](https://ci.ros2.org/view/packaging/job/packaging_linux-centos/506/)