### PR TITLE
add missing tango_icons_vendor

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -131,6 +131,10 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
     version: dashing-devel
+  ros-visualization/tango_icons_vendor:
+    type: git
+    url: https://github.com/ros-visualization/tango_icons_vendor.git
+    version: master
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git


### PR DESCRIPTION
Otherwise attempting to build Foxy following the [installation instructions](https://index.ros.org//doc/ros2/Installation/Foxy/Linux-Development-Setup)  fails as `rqt_gui` in foxy depends on `tango_icons_vendor` (a similar fix is likely needed on the foxy-release branch)