### PR TITLE
Track foxy branch instead of tag for ros2_tracing

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   micro-ROS/ros_tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: 1.0.2
+    version: foxy
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
This is similar to #958.

The background is that I'm working on adding the `tracetools` docs to docs.ros2.org (if that's possible). This means I unfortunately have to backport changes/improvements to the docs to the foxy branch. Therefore I need to update the `ros2.repos` file. Given #958/#957, I thought I'd change this one to simply track the foxy branch as well.