### PR TITLE
Revert "Temporarily pin FastDDS (#1027)"

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -38,7 +38,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: efaa0b59204930eac113e74cde2ba817be1a0045
+    version: 2.0.x
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
https://github.com/eProsima/Fast-DDS/issues/1385 has been fixed upstream. 