### PR TITLE
Update branch for ros_tutorials

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -166,7 +166,7 @@ repositories:
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: foxy-devel
+    version: galactic-devel
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Connects to https://github.com/ros/ros_tutorials/pull/100.
