### PR TITLE
[Dashing release] Bump to Fast DDS 1.8.4

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.11
+    version: v1.0.13
   eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-RTPS.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -31,10 +31,10 @@ repositories:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
     version: v1.0.13
-  eProsima/Fast-RTPS:
+  eProsima/Fast-DDS:
     type: git
-    url: https://github.com/eProsima/Fast-RTPS.git
-    version: v1.8.2
+    url: https://github.com/eProsima/Fast-DDS.git
+    version: v1.8.4
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
This PR bumps Fast CDR to v1.0.13 and Fast DDS to v1.8.4

There are neither API nor ABI breaks between versions, and #1020 may be fixed with this change