### PR TITLE
[Dashing] Update Fast DDS

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v1.8.2
+    version: 1.8.x
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.11
+    version: v1.0.13
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
This PR bumps Fast CDR to v1.0.13 and sets Fast DDS to branch 1.8.x

This way, bug fixes on Fast DDS affecting dashing (like #1020) could be directly incorporated into this distro.