### PR TITLE
[Foxy] Add the 'google_benchmark_vendor' package (#978)

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -15,6 +15,10 @@ repositories:
     type: git
     url: https://github.com/ament/ament_package.git
     version: foxy
+  ament/google_benchmark_vendor:
+    type: git
+    url: https://github.com/ament/google_benchmark_vendor.git
+    version: main
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git


### PR DESCRIPTION
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12598)](http://ci.ros2.org/job/ci_linux/12598/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7564)](http://ci.ros2.org/job/ci_linux-aarch64/7564/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10310)](http://ci.ros2.org/job/ci_osx/10310/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12522)](http://ci.ros2.org/job/ci_windows/12522/)

Signed-off-by: Scott K Logan <logans@cottsay.net>