### PR TITLE
[Foxy] Add mimick_vendor package to ros2.repos (#985)

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -215,6 +215,10 @@ repositories:
     type: git
     url: https://github.com/ros2/message_filters.git
     version: foxy
+  ros2/mimick_vendor:
+    type: git
+    url: https://github.com/ros2/mimick_vendor.git
+    version: master
   ros2/orocos_kinematics_dynamics:
     type: git
     url: https://github.com/ros2/orocos_kinematics_dynamics.git


### PR DESCRIPTION
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12599)](http://ci.ros2.org/job/ci_linux/12599/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7565)](http://ci.ros2.org/job/ci_linux-aarch64/7565/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10311)](http://ci.ros2.org/job/ci_osx/10311/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12523)](http://ci.ros2.org/job/ci_windows/12523/)

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>