### PR TITLE
[Foxy] Add the 'performance_test_fixture' repository (#983)

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -223,6 +223,10 @@ repositories:
     type: git
     url: https://github.com/ros2/orocos_kinematics_dynamics.git
     version: foxy
+  ros2/performance_test_fixture:
+    type: git
+    url: https://github.com/ros2/performance_test_fixture.git
+    version: main
   ros2/python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git


### PR DESCRIPTION
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12603)](http://ci.ros2.org/job/ci_linux/12603/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7566)](http://ci.ros2.org/job/ci_linux-aarch64/7566/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10312)](http://ci.ros2.org/job/ci_osx/10312/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12524)](http://ci.ros2.org/job/ci_windows/12524/)

Signed-off-by: Scott K Logan <logans@cottsay.net>