### PR TITLE
Update ros2_tracing repo URL and directory

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -43,10 +43,6 @@ repositories:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
     version: master
-  micro-ROS/ros_tracing/ros2_tracing:
-    type: git
-    url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-    version: master
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
@@ -66,6 +62,10 @@ repositories:
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
+    version: master
+  ros-tracing/ros2_tracing:
+    type: git
+    url: https://gitlab.com/ros-tracing/ros2_tracing.git
     version: master
   ros-visualization/interactive_markers:
     type: git


### PR DESCRIPTION
This moves `ros2_tracing` from 
https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing to 
https://gitlab.com/ros-tracing/ros2_tracing, and from `micro-ROS/ros_tracing/ros2_tracing/` to `ros-tracing/ros2_tracing`.

* Foxy: https://github.com/ros2/ros2/pull/1044
* Eloquent: https://github.com/ros2/ros2/pull/1043
* rosdistro: https://github.com/ros/rosdistro/pull/26801

Original issue: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/issues/106