### PR TITLE
Move urdfdom back to the 'ros' organization.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -171,6 +171,10 @@ repositories:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
     version: master
+  ros/urdfdom:
+    type: git
+    url: https://github.com/ros/urdfdom.git
+    version: ros2
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
@@ -390,10 +394,6 @@ repositories:
   ros2/urdf:
     type: git
     url: https://github.com/ros2/urdf.git
-    version: ros2
-  ros2/urdfdom:
-    type: git
-    url: https://github.com/ros2/urdfdom.git
     version: ros2
   ros2/yaml_cpp_vendor:
     type: git


### PR DESCRIPTION
And also move it to the 'ros' subdirectory.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>