### PR TITLE
Switch the qt_gui_core branch to Galactic.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -82,7 +82,7 @@ repositories:
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: foxy-devel
+    version: galactic-devel
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
We're going to land some changes that are not backwards
compatible to Foxy, so use a new branch.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>