### PR TITLE
Add pybind11_vendor to ros2.repos for Foxy

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -235,6 +235,10 @@ repositories:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
     version: main
+  ros2/pybind11_vendor:
+    type: git
+    url: https://github.com/ros2/pybind11_vendor.git
+    version: master
   ros2/python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git


### PR DESCRIPTION
@jacobperron not sure if we want to track a separate `foxy` branch on pybind11_vendor? I don't have write access there so I couldn't create one