### PR TITLE
Update rqt_publisher branch to foxy-devel

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -114,7 +114,7 @@ repositories:
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
-    version: dashing-devel
+    version: foxy-devel
   ros-visualization/rqt_py_console:
     type: git
     url: https://github.com/ros-visualization/rqt_py_console.git


### PR DESCRIPTION
After https://github.com/ros-visualization/rqt_publisher/pull/24