### PR TITLE
Update Fast CDR to v1.0.20

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.19
+    version: v1.0.20
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
Updating Fast CDR to v1.0.20 should help to fix some interoperability issues on Fast DDS (like [this one](https://github.com/eProsima/Fast-DDS/issues/1762))

It would be interesting to backport this, at least to foxy