### PR TITLE
Remove rmw_connext and the typesupport from ros2.repos.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -287,10 +287,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw.git
     version: master
-  ros2/rmw_connext:
-    type: git
-    url: https://github.com/ros2/rmw_connext.git
-    version: master
   ros2/rmw_connextdds:
     type: git
     url: https://github.com/rticommunity/rmw_connextdds.git
@@ -354,10 +350,6 @@ repositories:
   ros2/rosidl_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_typesupport.git
-    version: master
-  ros2/rosidl_typesupport_connext:
-    type: git
-    url: https://github.com/ros2/rosidl_typesupport_connext.git
     version: master
   ros2/rosidl_typesupport_fastrtps:
     type: git


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Part of https://github.com/rticommunity/rmw_connextdds/issues/9