### PR TITLE
Move rmw_connextdds to ros2 organization

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -293,7 +293,7 @@ repositories:
     version: master
   ros2/rmw_connextdds:
     type: git
-    url: https://github.com/rticommunity/rmw_connextdds.git
+    url: https://github.com/ros2/rmw_connextdds.git
     version: master
   ros2/rmw_cyclonedds:
     type: git


### PR DESCRIPTION
This PR updates the URL for `rmw_connextdds` now that the repository was transfered to the `ros2` GitHub organization.