### PR TITLE
Update rqt_graph to galactic-devel

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -102,7 +102,7 @@ repositories:
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: foxy-devel
+    version: galactic-devel
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git


### PR DESCRIPTION
After https://github.com/ros-visualization/rqt_graph/pull/61.

I'll rerelease the package in rolling and update tracks in the release repository after this.