### PR TITLE
Change the top-level link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Documentation is at https://index.ros.org/doc/ros2/
+Documentation is at https://docs.ros.org


### PR DESCRIPTION
Make it point at https://docs.ros.org

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>