### PR TITLE
Switch rqt_console branch from dashing-devel to ros2

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -102,7 +102,7 @@ repositories:
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: dashing-devel
+    version: ros2
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git


### PR DESCRIPTION
It seems we were not targeting `rolling`.