### PR TITLE
Pin cyclonedds temporarily to avoid CI failures

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 45a9ac292a1863df7d79f7d1919d19b09f1f9807
+    version: 0.8.0beta4
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: iceoryx
+    version: 45a9ac292a1863df7d79f7d1919d19b09f1f9807
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git


### PR DESCRIPTION
CI builds are failing after https://github.com/eclipse-cyclonedds/cyclonedds/pull/768, which requires https://github.com/ros2/rmw_cyclonedds/pull/306.

I think we don't want to introduce API breaks at this point.
Pinning cyclonedds temporaly will put out the CI fire :fire: :fire_engine: until that commit can be reverted.