### PR TITLE
Add a PR check for viability and formatting

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,24 @@
+---
+name: ROS 2 Repos Check
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  format_and_validity:
+    name: Format and Validity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: python3 -m pip install vcstool yamllint
+      - name: Validate formatting
+        run: >
+          yamllint ros2.repos
+          -f github
+          -d "{extends: default, rules: {document-start: {present: false}, key-ordering: {}}}"
+      - name: Validate repositories
+        run: vcs validate --input ros2.repos


### PR DESCRIPTION
~~This change adds a simple-and-sweet import/export round-trip to verify that all of the repository information is viable and that the format matches what `vcstool` exports.~~

This change adds some YAML format validation (including alphabetical ordering), as well as a validation pass using `vcstool`.

Requires #1134