### PR TITLE
Update release versions for the final patch release.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v1.8.2
+    version: v1.8.4
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
@@ -62,7 +62,7 @@ repositories:
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
-    version: 1.0.5
+    version: 1.0.7
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
@@ -134,7 +134,7 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 0.7.0
+    version: 0.7.1
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
@@ -170,7 +170,7 @@ repositories:
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.8.9
+    version: 0.8.10
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -190,7 +190,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 0.7.9
+    version: 0.7.10
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -202,7 +202,7 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 0.7.15
+    version: 0.7.16
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
@@ -246,7 +246,7 @@ repositories:
   ros/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
-    version: 2.2.4
+    version: 2.2.5
   ros2/ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git
@@ -254,7 +254,7 @@ repositories:
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git
-    version: 0.7.7
+    version: 0.7.9
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
@@ -298,7 +298,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 6.1.7
+    version: 6.1.8
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -31,9 +31,9 @@ repositories:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
     version: v1.0.13
-  eProsima/Fast-RTPS:
+  eProsima/Fast-DDS:
     type: git
-    url: https://github.com/eProsima/Fast-RTPS.git
+    url: https://github.com/eProsima/Fast-DDS.git
     version: v1.8.2
   osrf/osrf_pycommon:
     type: git
@@ -243,9 +243,9 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_opensplice.git
     version: 0.7.3
-  ros2/robot_state_publisher:
+  ros/robot_state_publisher:
     type: git
-    url: https://github.com/ros2/robot_state_publisher.git
+    url: https://github.com/ros/robot_state_publisher.git
     version: 2.2.4
   ros2/ros_testing:
     type: git
@@ -335,9 +335,9 @@ repositories:
     type: git
     url: https://github.com/ros2/urdf.git
     version: 2.2.0
-  ros2/urdfdom:
+  ros/urdfdom:
     type: git
-    url: https://github.com/ros2/urdfdom.git
+    url: https://github.com/ros/urdfdom.git
     version: 2.2.0
   ros2/yaml_cpp_vendor:
     type: git

--- a/ros2.repos
+++ b/ros2.repos
@@ -31,7 +31,7 @@ repositories:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
     version: v1.0.13
-  eProsima/Fast-DDS:
+  eProsima/Fast-RTPS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
     version: v1.8.4
@@ -243,7 +243,7 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_opensplice.git
     version: 0.7.3
-  ros/robot_state_publisher:
+  ros2/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
     version: 2.2.5
@@ -335,7 +335,7 @@ repositories:
     type: git
     url: https://github.com/ros2/urdf.git
     version: 2.2.0
-  ros/urdfdom:
+  ros2/urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
     version: 2.2.0


### PR DESCRIPTION
Some repository names have changed and other repositories have been
merged from their ROS 2 fork back into the upstream repository.

Additionally updates the release versions for this patch release.