### PR TITLE
Set ros_tutorials branch to rolling-devel

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -178,7 +178,7 @@ repositories:
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: galactic-devel
+    version: rolling-devel
   ros/urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git


### PR DESCRIPTION
The branch was created (https://github.com/ros/ros_tutorials/issues/120) and then used in `rosdistro` for Rolling (https://github.com/ros/rosdistro/pull/29857), but we're still using `galactic-devel` here.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>