### PR TITLE
Use a branch of ament_lint with clang-tidy fixed and enabled by default.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -291,4 +291,3 @@ repositories:
     type: git
     url: https://github.com/ros2/yaml_cpp_vendor.git
     version: master
-

--- a/ros2.repos
+++ b/ros2.repos
@@ -14,7 +14,7 @@ repositories:
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: master
+    version: spaceros/enable-clang-tidy
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git


### PR DESCRIPTION
This package list may shrink or be reorganized periodically.

This branch of ament_lint includes two changes for ament_lint_clang_tidy
to address usage issues and an additional commit to add it to
ament_lint_common so it will be enabled by default for all repositories
using ament_lint_common and ament_lint_auto.