### PR TITLE
Set libstatistics_collector to galactic for Galactic

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -70,7 +70,7 @@ repositories:
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: galactic-devel
+    version: galactic
   ros-tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/ros-tracing/ros2_tracing.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -70,7 +70,7 @@ repositories:
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: master
+    version: galactic-devel
   ros-tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/ros-tracing/ros2_tracing.git


### PR DESCRIPTION
https://github.com/ros-tooling/libstatistics_collector/pull/116 broke Galactic builds because `libstatistics_collector`'s `master` branch is used for Rolling and Galactic, but https://github.com/ros2/rosidl/pull/606 is only in Rolling.

The `galactic` branch points to a commit before https://github.com/ros-tooling/libstatistics_collector/pull/116: https://github.com/ros-tooling/libstatistics_collector/tree/galactic

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>