### PR TITLE
qt_gui_core devel branch galactic-devel -> main

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -86,7 +86,7 @@ repositories:
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: galactic-devel
+    version: main
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
The development branch for rolling is now `main` instead of `galactic-devel`