### PR TITLE
Add ignition math6 and cmake2 vendor packages

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -47,6 +47,14 @@ repositories:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
     version: release_1.0
+  ignition/ignition_cmake2_vendor:
+    type: git
+    url: https://github.com/ignition-release/ignition_cmake2_vendor.git
+    version: main
+  ignition/ignition_math6_vendor:
+    type: git
+    url: https://github.com/ignition-release/ignition_math6_vendor.git
+    version: main
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
@@ -219,14 +227,6 @@ repositories:
     type: git
     url: https://github.com/ros2/geometry2.git
     version: ros2
-  ros2/ignition_cmake2_vendor:
-    type: git
-    url: https://github.com/ignition-release/ignition_cmake2_vendor.git
-    version: main
-  ros2/ignition_math6_vendor:
-    type: git
-    url: https://github.com/ignition-release/ignition_math6_vendor.git
-    version: main
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -219,6 +219,14 @@ repositories:
     type: git
     url: https://github.com/ros2/geometry2.git
     version: ros2
+  ros2/ignition_cmake2_vendor:
+    type: git
+    url: https://github.com/ignition-release/ignition_cmake2_vendor.git
+    version: main
+  ros2/ignition_math6_vendor:
+    type: git
+    url: https://github.com/ignition-release/ignition_math6_vendor.git
+    version: main
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

Add ignition math6 and cmake2 vendor packages. This dependency is required by this PR in RVIZ2 https://github.com/ros2/rviz/pull/751