### PR TITLE
[Space ROS] Rename target branch of ament_lint.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -14,7 +14,7 @@ repositories:
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: spaceros/enable-clang-tidy
+    version: spaceros-enable-clang-tidy
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git


### PR DESCRIPTION
Renaming this branch to spaceros-enable-clang-tidy in order to remove spaceros/enable-clang-tidy and enable the use of 'spaceros' as a branch name in the ament_lint repository.