### PR TITLE
Add keyboard_handler to ros2.repos

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -75,6 +75,10 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
     version: ros2
+  ros-tooling/keyboard_handler:
+    type: git
+    url: https://github.com/ros-tooling/keyboard_handler.git
+    version: main
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
We will be adding this as a dependency of rosbag2 for Humble, so it will need to be in this file for CI builds