### PR TITLE
[Space ROS] Fix branch name

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -38,7 +38,7 @@ repositories:
   cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: release/0.8.x
+    version: releases/0.8.x
   demos:
     type: git
     url: https://github.com/ros2/demos.git


### PR DESCRIPTION
This is a correction of #1185 which has an incorrect branch name `release/0.8.x` instead of `releases/0.8.x`.