### PR TITLE
[Space ROS] Add ros_testing, a test dependency of ros2cli packages.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -175,6 +175,10 @@ repositories:
     type: git
     url: https://github.com/ros/ros_environment.git
     version: rolling
+  ros_testing:
+    type: git
+    url: https://github.com/ros2/ros_testing.git
+    version: master
   rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git


### PR DESCRIPTION
This package is missing from the current repos list due to a quirk of rosinstall_generator.

