### PR TITLE
Switch to the master branch for urdfdom

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -190,7 +190,7 @@ repositories:
   ros/urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
-    version: ros2
+    version: master
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
In https://github.com/ros/urdfdom/pull/158 and https://github.com/ros/urdfdom/pull/161,
we merged the ros2 branch onto the master branch so there would be single,
unified release branch for all of urdfdom.  Now that that is done, we should switch
to using the master branch of urdfdom.