### PR TITLE
Foxy release versions 2021-10-13

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -354,7 +354,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 8.2.4
+    version: 8.2.5
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git


### PR DESCRIPTION
To resolve https://github.com/ros2/rviz/issues/782

**Packaging:**
* Linux: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=468)](https://ci.ros2.org/job/ci_packaging_linux/468/)
* Linux-aarch64: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=73)](https://ci.ros2.org/job/ci_packaging_linux-aarch64/73/)
* macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_osx&build=82)](https://ci.ros2.org/job/ci_packaging_osx/82/)
* Windows Release: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=183)](https://ci.ros2.org/job/ci_packaging_windows/183/)
* Windows Debug: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=184)](https://ci.ros2.org/job/ci_packaging_windows/184/)
* CentOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-rhel&build=32)](https://ci.ros2.org/job/ci_packaging_linux-rhel/32/)