### PR TITLE
Update galactic-release Fast-DDS tag

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.3.1
+    version: v2.3.4
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
The current release of Fast-DDS (as fastrtps) in Galactic on the ROS
build farm is 2.3.4 merged in ros/rosdistro#30403.