### PR TITLE
Add cobra_vendor and ament_cobra repos

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -7,13 +7,13 @@ repositories:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
     version: master
+  ament_cobra:
+    type: git
+    url: https://github.com/ament/ament_cobra.git
   ament_ikos:
     type: git
     url: https://github.com/ament/ament_ikos.git
     version: main
-  ament_cobra:
-    type: git
-    url: https://github.com/ament/ament_cobra.git
   ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -30,6 +30,10 @@ repositories:
     type: git
     url: https://github.com/ros/class_loader.git
     version: ros2
+  cobra_vendor:
+    type: git
+    url: https://github.com/nuclearsandwich/cobra_vendor
+    version: latest
   common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -11,6 +11,9 @@ repositories:
     type: git
     url: https://github.com/ament/ament_ikos.git
     version: main
+  ament_cobra:
+    type: git
+    url: https://github.com/ament/ament_cobra.git
   ament_index:
     type: git
     url: https://github.com/ament/ament_index.git


### PR DESCRIPTION
Update the spaceros branch of the ros2.repos file to add cobra_vendor and ament_cobra packages.