### PR TITLE
Foxy release versions 2022-02-08

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -18,7 +18,7 @@ repositories:
   ament/google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
-    version: 0.0.6
+    version: 0.0.7
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
@@ -94,7 +94,7 @@ repositories:
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: 1.1.2
+    version: 1.1.3
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git
@@ -102,7 +102,7 @@ repositories:
   ros-visualization/rqt_plot:
     type: git
     url: https://github.com/ros-visualization/rqt_plot.git
-    version: 1.1.0
+    version: 1.1.1
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
@@ -150,7 +150,7 @@ repositories:
   ros/pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: 2.5.3
+    version: 2.5.4
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
@@ -182,7 +182,7 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 2.0.4
+    version: 2.0.5
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
@@ -206,15 +206,15 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.13.12
+    version: 0.13.13
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 0.10.6
+    version: 0.10.8
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.11.4
+    version: 0.11.6
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -226,7 +226,7 @@ repositories:
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
-    version: 0.2.6
+    version: 0.2.7
   ros2/orocos_kinematics_dynamics:
     type: git
     url: https://github.com/ros2/orocos_kinematics_dynamics.git
@@ -234,7 +234,7 @@ repositories:
   ros2/performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
-    version: 0.0.7
+    version: 0.0.8
   ros2/python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git
@@ -242,7 +242,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 1.1.11
+    version: 1.1.13
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -254,11 +254,11 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 2.4.0
+    version: 2.4.1
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 1.0.7
+    version: 1.0.8
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
@@ -282,7 +282,7 @@ repositories:
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: 0.7.7
+    version: 0.7.8
   ros2/rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
@@ -290,11 +290,11 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 1.2.6
+    version: 1.3.0
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 1.0.2
+    version: 1.0.3
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git
@@ -302,7 +302,7 @@ repositories:
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.9.10
+    version: 0.9.11
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -314,7 +314,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.3.8
+    version: 0.3.9
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -330,7 +330,7 @@ repositories:
   ros2/rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: 0.9.4
+    version: 0.9.5
   ros2/rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
@@ -354,7 +354,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 8.2.5
+    version: 8.2.6
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -362,11 +362,11 @@ repositories:
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: 0.9.4
+    version: 0.9.5
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git
-    version: 0.9.1
+    version: 0.9.2
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git


### PR DESCRIPTION
Closes #1237 

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16093)](http://ci.ros2.org/job/ci_linux/16093/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=10738)](http://ci.ros2.org/job/ci_linux-aarch64/10738/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16427)](http://ci.ros2.org/job/ci_windows/16427/)
* CentOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=183)](https://ci.ros2.org/view/All/job/ci_linux-rhel/183/)
  * Edit: looks like an improvement over CI for previous patch release (https://ci.ros2.org/view/All/job/ci_linux-rhel/155)

Packaging:

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=476)](https://ci.ros2.org/job/ci_packaging_linux/476/)
* Linux-aarch64 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=85)](https://ci.ros2.org/job/ci_packaging_linux-aarch64/85/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=186)](https://ci.ros2.org/job/ci_packaging_windows/186/)
* Windows Debug [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=190)](https://ci.ros2.org/job/ci_packaging_windows/190/)
* CentOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-rhel&build=33)](https://ci.ros2.org/view/All/job/ci_packaging_linux-rhel/33/)