### PR TITLE
 Switch google_benchmark_vendor to the galactic branch

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -18,7 +18,7 @@ repositories:
   ament/google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
-    version: main
+    version: galactic
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git


### PR DESCRIPTION
So that Rolling development happens on main