### PR TITLE
Remove ros1_bridge due to Jammy incompatibility

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -323,10 +323,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
     version: master
-  ros2/ros1_bridge:
-    type: git
-    url: https://github.com/ros2/ros1_bridge.git
-    version: master
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git


### PR DESCRIPTION
`ros1_bridge` is currently incompatible with Jammy, as there isn't a distribution of ROS1 packaged for it.  This causes warnings in the packaging job. https://ci.ros2.org/view/packaging/job/packaging_linux/2612/cmake/new/

This removes it from ros2.repos.

Signed-off-by: Michael Carroll <michael@openrobotics.org>