### PR TITLE
Remove rqt_top from ros2.repos.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -151,10 +151,6 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/rqt_srv.git
     version: crystal-devel
-  ros-visualization/rqt_top:
-    type: git
-    url: https://github.com/ros-visualization/rqt_top.git
-    version: crystal-devel
   ros-visualization/rqt_topic:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git


### PR DESCRIPTION
As it stands, it only shows a list of nodes and no other information.
To make it actually useful, we'd have to do a bunch more work,
so remove it until someone steps up to do that work.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I'll also backport this change to Humble once it is approved.