### PR TITLE
Set Humble release versions

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: e6e7eac5a642f606fdaa40a0a2a16617ae9384da
+    version: 2.6.x
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -42,11 +42,11 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 0e2cd3e303be2171dd0e4fc685cc5031f70b0f52
+    version: releases/0.9.x
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
-    version: v2.0.2
+    version: release_2.0
   ignition/ignition_cmake2_vendor:
     type: git
     url: https://github.com/ignition-release/ignition_cmake2_vendor.git
@@ -62,7 +62,7 @@ repositories:
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: 869da204dd829308380df5a33e432670e474e54a
+    version: 1.5.1
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
@@ -78,15 +78,15 @@ repositories:
   ros-tooling/keyboard_handler:
     type: git
     url: https://github.com/ros-tooling/keyboard_handler.git
-    version: 53bccc93ef25d1c54aaa4fa262ef097afee282aa
+    version: 0.0.4
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: ed40c1825fb17c244ddf69fb6c7927060dff812b
+    version: 1.2.0
   ros-tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/ros-tracing/ros2_tracing.git
-    version: 590a512db73d53398d8e4bcb1faa827484617eb2
+    version: 4.1.0
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
@@ -114,7 +114,7 @@ repositories:
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: d293cc3423c23547dfc430dde293cc15304da88b
+    version: 2.0.2
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
@@ -254,7 +254,7 @@ repositories:
   ros2/performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
-    version: d736c276d292a78f9750aba39108d5222bf9629e
+    version: 0.0.8
   ros2/pybind11_vendor:
     type: git
     url: https://github.com/ros2/pybind11_vendor.git
@@ -334,7 +334,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: b32981ca35e468d927d313c8a06f6160dadb55b8
+    version: 0.15.2
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: 2.6.x
+    version: v2.6.0
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -42,11 +42,11 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: releases/0.9.x
+    version: 0.9.0
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
-    version: release_2.0
+    version: v2.0.2
   ignition/ignition_cmake2_vendor:
     type: git
     url: https://github.com/ignition-release/ignition_cmake2_vendor.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -2,31 +2,31 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: humble
+    version: 1.3.2
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: humble
+    version: 1.4.0
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: humble
+    version: 0.12.4
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: humble
+    version: 0.14.0
   ament/google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
-    version: humble
+    version: 0.1.1
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: humble
+    version: 1.10.9004
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: humble
+    version: 2.0.2
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
@@ -34,380 +34,380 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: 2.6.x
+    version: e6e7eac5a642f606fdaa40a0a2a16617ae9384da
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: master
+    version: v1.2.1
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: releases/0.9.x
+    version: 0e2cd3e303be2171dd0e4fc685cc5031f70b0f52
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
-    version: release_2.0
+    version: v2.0.2
   ignition/ignition_cmake2_vendor:
     type: git
     url: https://github.com/ignition-release/ignition_cmake2_vendor.git
-    version: humble
+    version: 0.0.2
   ignition/ignition_math6_vendor:
     type: git
     url: https://github.com/ignition-release/ignition_math6_vendor.git
-    version: humble
+    version: 0.0.2
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: master
+    version: 2.1.0
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: master
+    version: 869da204dd829308380df5a33e432670e474e54a
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: humble
+    version: 3.1.4
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
-    version: humble
+    version: 2.4.0
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
-    version: humble
+    version: 2.1.0
   ros-tooling/keyboard_handler:
     type: git
     url: https://github.com/ros-tooling/keyboard_handler.git
-    version: humble
+    version: 53bccc93ef25d1c54aaa4fa262ef097afee282aa
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: humble
+    version: ed40c1825fb17c244ddf69fb6c7927060dff812b
   ros-tracing/ros2_tracing:
     type: git
     url: https://gitlab.com/ros-tracing/ros2_tracing.git
-    version: humble
+    version: 590a512db73d53398d8e4bcb1faa827484617eb2
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
-    version: humble
+    version: 2.3.2
   ros-visualization/python_qt_binding:
     type: git
     url: https://github.com/ros-visualization/python_qt_binding.git
-    version: humble
+    version: 1.1.1
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: humble
+    version: 2.2.1
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
-    version: humble
+    version: 1.1.4
   ros-visualization/rqt_action:
     type: git
     url: https://github.com/ros-visualization/rqt_action.git
-    version: humble
+    version: 2.0.1
   ros-visualization/rqt_bag:
     type: git
     url: https://github.com/ros-visualization/rqt_bag.git
-    version: humble
+    version: 1.1.3
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: humble
+    version: d293cc3423c23547dfc430dde293cc15304da88b
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: humble
+    version: 1.2.1
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git
-    version: humble
+    version: 1.0.6
   ros-visualization/rqt_plot:
     type: git
     url: https://github.com/ros-visualization/rqt_plot.git
-    version: humble
+    version: 1.1.2
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
-    version: humble
+    version: 1.1.3
   ros-visualization/rqt_py_console:
     type: git
     url: https://github.com/ros-visualization/rqt_py_console.git
-    version: humble
+    version: 1.0.2
   ros-visualization/rqt_reconfigure:
     type: git
     url: https://github.com/ros-visualization/rqt_reconfigure.git
-    version: humble
+    version: 1.0.8
   ros-visualization/rqt_service_caller:
     type: git
     url: https://github.com/ros-visualization/rqt_service_caller.git
-    version: humble
+    version: 1.0.5
   ros-visualization/rqt_shell:
     type: git
     url: https://github.com/ros-visualization/rqt_shell.git
-    version: humble
+    version: 1.0.2
   ros-visualization/rqt_srv:
     type: git
     url: https://github.com/ros-visualization/rqt_srv.git
-    version: humble
+    version: 1.0.3
   ros-visualization/rqt_topic:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
-    version: humble
+    version: 1.2.3
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: humble
+    version: 0.1.1
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
-    version: humble
+    version: 2.2.0
   ros/kdl_parser:
     type: git
     url: https://github.com/ros/kdl_parser.git
-    version: humble
+    version: 2.6.2
   ros/pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: humble
+    version: 5.1.0
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
-    version: humble
+    version: 3.1.0
   ros/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
-    version: humble
+    version: 3.0.2
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: humble
+    version: 3.2.1
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: humble
+    version: 1.4.2
   ros/urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
-    version: humble
+    version: 3.0.2
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
-    version: humble
+    version: 1.0.6
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: humble
+    version: 0.10.0
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: humble
+    version: 4.2.2
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
-    version: humble
+    version: 1.4.0
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: humble
+    version: 0.20.2
   ros2/eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
-    version: humble
+    version: 0.1.1
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: humble
+    version: 0.9.3
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: humble
+    version: 0.15.0
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: humble
+    version: 0.25.0
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: humble
+    version: 1.0.2
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: humble
+    version: 0.19.3
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: humble
+    version: 1.2.2
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: humble
+    version: 4.3.1
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
-    version: humble
+    version: 0.2.8
   ros2/orocos_kdl_vendor:
     type: git
     url: https://github.com/ros2/orocos_kdl_vendor.git
-    version: humble
+    version: 0.2.2
   ros2/performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
-    version: main
+    version: d736c276d292a78f9750aba39108d5222bf9629e
   ros2/pybind11_vendor:
     type: git
     url: https://github.com/ros2/pybind11_vendor.git
-    version: humble
+    version: 2.4.1
   ros2/python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git
-    version: humble
+    version: 0.10.0
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: humble
+    version: 5.3.1
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: humble
+    version: 1.2.0
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: humble
+    version: 2.3.0
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: humble
+    version: 16.0.1
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: humble
+    version: 3.3.4
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: humble
+    version: 2.4.0
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: humble
+    version: 5.1.1
   ros2/realtime_support:
     type: git
     url: https://github.com/ros2/realtime_support.git
-    version: humble
+    version: 0.13.0
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: humble
+    version: 6.1.0
   ros2/rmw_connextdds:
     type: git
     url: https://github.com/ros2/rmw_connextdds.git
-    version: humble
+    version: 0.11.1
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: humble
+    version: 1.3.3
   ros2/rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
-    version: humble
+    version: 1.6.0
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: humble
+    version: 6.2.1
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: humble
+    version: 2.8.1
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: humble
+    version: 0.18.3
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
-    version: humble
+    version: 0.1.1
   ros2/ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git
-    version: humble
+    version: 0.4.0
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: humble
+    version: b32981ca35e468d927d313c8a06f6160dadb55b8
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: humble
+    version: 3.1.3
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: humble
+    version: 0.8.1
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: humble
+    version: 1.2.0
   ros2/rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: humble
+    version: 0.14.2
   ros2/rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
-    version: humble
+    version: 0.9.2
   ros2/rosidl_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_typesupport.git
-    version: humble
+    version: 2.0.0
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: humble
+    version: 2.2.0
   ros2/rpyutils:
     type: git
     url: https://github.com/ros2/rpyutils.git
-    version: humble
+    version: 0.2.1
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: humble
+    version: 11.2.2
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
-    version: humble
+    version: 1.3.0
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: humble
+    version: 0.10.4
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git
-    version: humble
+    version: 0.12.3
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
-    version: humble
+    version: 0.9.1
   ros2/tinyxml2_vendor:
     type: git
     url: https://github.com/ros2/tinyxml2_vendor.git
-    version: humble
+    version: 0.7.5
   ros2/tinyxml_vendor:
     type: git
     url: https://github.com/ros2/tinyxml_vendor.git
-    version: humble
+    version: 0.8.3
   ros2/tlsf:
     type: git
     url: https://github.com/ros2/tlsf.git
-    version: humble
+    version: 0.7.0
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: humble
+    version: 2.2.1
   ros2/urdf:
     type: git
     url: https://github.com/ros2/urdf.git
-    version: humble
+    version: 2.6.0
   ros2/yaml_cpp_vendor:
     type: git
     url: https://github.com/ros2/yaml_cpp_vendor.git
-    version: humble
+    version: 8.0.1


### PR DESCRIPTION
This is the result of running the following command on the Humble repos cloned from the repos file on the `humble` branch.
```bash
vcs export –exact-with-tags src
```