### PR TITLE
Change ros2_tracing repo URL to GitHub

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -83,10 +83,6 @@ repositories:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
     version: humble
-  ros-tracing/ros2_tracing:
-    type: git
-    url: https://gitlab.com/ros-tracing/ros2_tracing.git
-    version: humble
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
@@ -318,6 +314,10 @@ repositories:
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
+    version: humble
+  ros2/ros2_tracing:
+    type: git
+    url: https://github.com/ros2/ros2_tracing.git
     version: humble
   ros2/ros2cli:
     type: git


### PR DESCRIPTION
See: https://gitlab.com/ros-tracing/ros2_tracing/-/issues/144

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>