### PR TITLE
Change ros2_tracing repo URL to GitHub

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -63,10 +63,6 @@ repositories:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
     version: foxy-devel
-  ros-tracing/ros2_tracing:
-    type: git
-    url: https://gitlab.com/ros-tracing/ros2_tracing.git
-    version: foxy
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
@@ -298,6 +294,10 @@ repositories:
   ros2/ros1_bridge:
     type: git
     url: https://github.com/ros2/ros1_bridge.git
+    version: foxy
+  ros2/ros2_tracing:
+    type: git
+    url: https://github.com/ros2/ros2_tracing.git
     version: foxy
   ros2/ros2cli:
     type: git


### PR DESCRIPTION
See: https://gitlab.com/ros-tracing/ros2_tracing/-/issues/144

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>