### PR TITLE
[galactic] Update source branches for rqt_action and rqt_console

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -146,7 +146,7 @@ repositories:
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: humble
+    version: galactic
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -146,7 +146,7 @@ repositories:
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: master
+    version: humble
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -90,7 +90,7 @@ repositories:
   ros-visualization/rqt_action:
     type: git
     url: https://github.com/ros-visualization/rqt_action.git
-    version: ros2
+    version: galactic
   ros-visualization/rqt_bag:
     type: git
     url: https://github.com/ros-visualization/rqt_bag.git
@@ -98,7 +98,7 @@ repositories:
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: ros2
+    version: galactic
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git


### PR DESCRIPTION
I also noticed that we're tracking the `ros2` branch of [rqt_bag](https://github.com/ros-visualization/rqt_bag) for both Rolling and Galactic (while Humble is tracking it's own, older branch). I'm not sure what to do in that case. Open to suggestions.