### PR TITLE
[foxy] Update source branches for rqt_console and tango_icons_vendor

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -134,7 +134,7 @@ repositories:
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: humble
+    version: foxy
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -86,7 +86,7 @@ repositories:
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: dashing-devel
+    version: foxy-devel
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
@@ -134,7 +134,7 @@ repositories:
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: master
+    version: humble
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git


### PR DESCRIPTION
The branch for `rqt_console` was updated during the last release, but not updated here.

`tango_icons_vendor` now has it's rolling branch synced to master, so I'm targeting a new `foxy` branch instead.