### PR TITLE
Foxy release versions 2022-09-28

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 0.9.9
+    version: 0.9.11
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.9.6
+    version: 0.9.7
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -18,7 +18,7 @@ repositories:
   ament/google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
-    version: 0.0.7
+    version: 0.0.3
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
@@ -34,11 +34,11 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.1.1
+    version: v2.1.2
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.1.0
+    version: v1.2.1
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
@@ -63,10 +63,6 @@ repositories:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
     version: 1.0.1
-  ros-tracing/ros2_tracing:
-    type: git
-    url: https://gitlab.com/ros-tracing/ros2_tracing.git
-    version: 1.0.5
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
@@ -90,7 +86,7 @@ repositories:
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: 1.1.1
+    version: 1.1.2
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
@@ -106,7 +102,7 @@ repositories:
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
-    version: 1.1.3
+    version: 1.3.0
   ros-visualization/rqt_py_console:
     type: git
     url: https://github.com/ros-visualization/rqt_py_console.git
@@ -134,15 +130,15 @@ repositories:
   ros-visualization/rqt_topic:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
-    version: 1.2.2
+    version: 1.3.0
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: 0.1.0
+    version: 0.1.1
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
-    version: 2.0.2
+    version: 2.0.3
   ros/kdl_parser:
     type: git
     url: https://github.com/ros/kdl_parser.git
@@ -162,11 +158,11 @@ repositories:
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: 2.5.0
+    version: 2.5.1
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: 1.2.5
+    version: 1.2.6
   ros/urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
@@ -190,7 +186,7 @@ repositories:
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: 0.9.3
+    version: 0.9.4
   ros2/eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
@@ -210,11 +206,11 @@ repositories:
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 0.10.8
+    version: 0.10.9
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.11.6
+    version: 0.11.7
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -226,15 +222,15 @@ repositories:
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
-    version: 0.2.7
+    version: 0.2.6
   ros2/orocos_kinematics_dynamics:
     type: git
     url: https://github.com/ros2/orocos_kinematics_dynamics.git
-    version: 3.3.2
+    version: 3.3.4
   ros2/performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
-    version: 0.0.8
+    version: 0.0.9
   ros2/python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git
@@ -242,7 +238,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 1.1.13
+    version: 1.1.14
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -254,11 +250,11 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 2.4.1
+    version: 2.4.2
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 1.0.8
+    version: 1.0.10
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
@@ -266,7 +262,7 @@ repositories:
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: 1.1.3
+    version: 1.1.4
   ros2/realtime_support:
     type: git
     url: https://github.com/ros2/realtime_support.git
@@ -282,7 +278,7 @@ repositories:
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: 0.7.8
+    version: 0.7.11
   ros2/rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
@@ -290,7 +286,7 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 1.3.0
+    version: 1.3.1
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
@@ -299,10 +295,14 @@ repositories:
     type: git
     url: https://github.com/ros2/ros1_bridge.git
     version: 0.9.6
+  ros2/ros2_tracing:
+    type: git
+    url: https://github.com/ros2/ros2_tracing.git
+    version: 1.0.5
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.9.11
+    version: 0.9.12
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -318,7 +318,7 @@ repositories:
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 1.2.1
+    version: 1.3.0
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
@@ -330,7 +330,7 @@ repositories:
   ros2/rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: 0.9.5
+    version: 0.9.6
   ros2/rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
@@ -354,7 +354,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 8.2.6
+    version: 8.2.7
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -394,4 +394,4 @@ repositories:
   ros2/yaml_cpp_vendor:
     type: git
     url: https://github.com/ros2/yaml_cpp_vendor.git
-    version: 7.0.2
+    version: 7.0.3


### PR DESCRIPTION
Announcement: https://discourse.ros.org/t/preparing-for-foxy-sync-and-patch-release-2022-09-27/27464
Changes: https://github.com/orgs/ros2/projects/36

CI:
* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17399)](https://ci.ros2.org/job/ci_linux/17399/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11898)](http://ci.ros2.org/job/ci_linux-aarch64/11898/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17867)](http://ci.ros2.org/job/ci_windows/17867/)
* CentOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=255)](https://ci.ros2.org/view/All/job/ci_linux-rhel/255/)
  * Baseline: https://ci.ros2.org/view/All/job/ci_linux-rhel/183/

Packaging:
* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=523)](https://ci.ros2.org/job/ci_packaging_linux/523/)
* Linux-aarch64 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=98)](https://ci.ros2.org/job/ci_packaging_linux-aarch64/98/)
* Windows[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=205)](https://ci.ros2.org/job/ci_packaging_windows/205/)
* Windows Debug [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=206)](https://ci.ros2.org/job/ci_packaging_windows/206/)
* CentOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-rhel&build=34)](https://ci.ros2.org/job/ci_packaging_linux-rhel/34/)