### PR TITLE
Fix branch name for python_qt_binding

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -78,7 +78,7 @@ repositories:
   ros-visualization/python_qt_binding:
     type: git
     url: https://github.com/ros-visualization/python_qt_binding.git
-    version: main
+    version: galactic-devel
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git


### PR DESCRIPTION
This will make it match `rosdistro` (and reality).