### PR TITLE
Humble release versions 2023-01-10

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.12.4
+    version: 0.12.5
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -278,7 +278,7 @@ repositories:
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 3.3.6
+    version: 3.3.7
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -246,7 +246,7 @@ repositories:
   ros2/orocos_kdl_vendor:
     type: git
     url: https://github.com/ros2/orocos_kdl_vendor.git
-    version: 0.2.4
+    version: 0.2.5
   ros2/performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -38,7 +38,7 @@ repositories:
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.2.1
+    version: v1.2.2
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
@@ -66,7 +66,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: 3.1.4
+    version: 3.1.5
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -162,7 +162,7 @@ repositories:
   ros/kdl_parser:
     type: git
     url: https://github.com/ros/kdl_parser.git
-    version: 2.6.3
+    version: 2.6.4
   ros/pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
@@ -170,7 +170,7 @@ repositories:
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
-    version: 3.1.0
+    version: 3.1.1
   ros/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
@@ -198,15 +198,15 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 4.2.2
+    version: 4.2.3
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
-    version: 1.4.0
+    version: 1.4.1
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: 0.20.2
+    version: 0.20.3
   ros2/eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
@@ -222,15 +222,15 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.25.1
+    version: 0.25.2
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 1.0.3
+    version: 1.0.4
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.19.3
+    version: 0.19.4
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -254,7 +254,7 @@ repositories:
   ros2/pybind11_vendor:
     type: git
     url: https://github.com/ros2/pybind11_vendor.git
-    version: 2.4.1
+    version: 2.4.2
   ros2/python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git
@@ -274,11 +274,11 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 16.0.2
+    version: 16.0.3
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 3.3.5
+    version: 3.3.6
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
@@ -314,7 +314,7 @@ repositories:
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 2.8.1
+    version: 2.8.2
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
@@ -322,7 +322,7 @@ repositories:
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.18.4
+    version: 0.18.5
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -334,7 +334,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.15.3
+    version: 0.15.4
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -370,11 +370,11 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 11.2.4
+    version: 11.2.5
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
-    version: 1.3.0
+    version: 1.3.1
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
@@ -410,4 +410,4 @@ repositories:
   ros2/yaml_cpp_vendor:
     type: git
     url: https://github.com/ros2/yaml_cpp_vendor.git
-    version: 8.0.1
+    version: 8.0.2

--- a/ros2.repos
+++ b/ros2.repos
@@ -38,7 +38,7 @@ repositories:
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.2.2
+    version: v1.2.0
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git


### PR DESCRIPTION
Changes: https://github.com/orgs/ros2/projects/44

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17985)](http://ci.ros2.org/job/ci_linux/17985/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=12512)](http://ci.ros2.org/job/ci_linux-aarch64/12512/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=18617)](http://ci.ros2.org/job/ci_windows/18617/)
* RHEL [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=295)](http://ci.ros2.org/job/ci_linux-rhel/295/)

Packaging:
* https://ci.ros2.org/view/packaging/job/packaging_linux/2910/
* https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/2263/
* https://ci.ros2.org/view/packaging/job/packaging_linux-rhel/1411/
* https://ci.ros2.org/view/packaging/job/packaging_windows/2740/
* https://ci.ros2.org/view/packaging/job/packaging_windows_debug/1699/