### PR TITLE
Update ros2.repos

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.24
+    version: v1.0.26
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
Update to version 1.0.26 for:
Fix broken link to Fast CDR documentation (#127) 
Fix SerializeArray error when swaping the bytes (#126)