### PR TITLE
Humble release bump libstatistics_collector

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -82,7 +82,7 @@ repositories:
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: 1.3.0
+    version: 1.3.1
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git


### PR DESCRIPTION
Followup from https://github.com/ros/rosdistro/pull/36267.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18177)](http://ci.ros2.org/job/ci_linux/18177/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=12713)](http://ci.ros2.org/job/ci_linux-aarch64/12713/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=18838)](http://ci.ros2.org/job/ci_windows/18838/)
* RHEL [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=340)](http://ci.ros2.org/job/ci_linux-rhel/340/)

Packaging:
* https://ci.ros2.org/view/packaging/job/packaging_linux/2957/
* https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/2313/
* https://ci.ros2.org/view/packaging/job/packaging_linux-rhel/1458/
* https://ci.ros2.org/view/packaging/job/packaging_windows/2787/
* https://ci.ros2.org/view/packaging/job/packaging_windows_debug/1746/