### PR TITLE
Change osrf_testing_tools_cpp branch to humble

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -62,7 +62,7 @@ repositories:
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: master
+    version: humble
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
This goes along with previous distributions (foxy, eloquent, dashing, etc), and is more inline with what we do today.