### PR TITLE
Bump CycloneDDS to 0.10.x branch

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: releases/0.9.x
+    version: releases/0.10.x
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git


### PR DESCRIPTION
Part of #1359

Bumping cyclonedds to the 0.10.x branch solves all the windows `test_communication` test failures with the new discovery changes.