### PR TITLE
Update ros2.repos for Iron release

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -2,35 +2,35 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: rolling
+    version: iron
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: rolling
+    version: iron
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: rolling
+    version: iron
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: rolling
+    version: iron
   ament/google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
-    version: rolling
+    version: iron
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: rolling
+    version: iron
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: rolling
+    version: iron
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: master
+    version: v1.0.27
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
@@ -50,11 +50,11 @@ repositories:
   gazebo-release/gz_cmake2_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_cmake2_vendor.git
-    version: rolling
+    version: iron
   gazebo-release/gz_math6_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_math6_vendor.git
-    version: rolling
+    version: iron
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
@@ -62,364 +62,364 @@ repositories:
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: rolling
+    version: iron
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: rolling
+    version: iron
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
-    version: rolling
+    version: iron
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
-    version: rolling
+    version: iron
   ros-tooling/keyboard_handler:
     type: git
     url: https://github.com/ros-tooling/keyboard_handler.git
-    version: rolling
+    version: iron
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: rolling
+    version: iron
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
-    version: rolling
+    version: iron
   ros-visualization/python_qt_binding:
     type: git
     url: https://github.com/ros-visualization/python_qt_binding.git
-    version: rolling
+    version: iron
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: rolling
+    version: iron
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_action:
     type: git
     url: https://github.com/ros-visualization/rqt_action.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_bag:
     type: git
     url: https://github.com/ros-visualization/rqt_bag.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_plot:
     type: git
     url: https://github.com/ros-visualization/rqt_plot.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_py_console:
     type: git
     url: https://github.com/ros-visualization/rqt_py_console.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_reconfigure:
     type: git
     url: https://github.com/ros-visualization/rqt_reconfigure.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_service_caller:
     type: git
     url: https://github.com/ros-visualization/rqt_service_caller.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_shell:
     type: git
     url: https://github.com/ros-visualization/rqt_shell.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_srv:
     type: git
     url: https://github.com/ros-visualization/rqt_srv.git
-    version: rolling
+    version: iron
   ros-visualization/rqt_topic:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
-    version: rolling
+    version: iron
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: rolling
+    version: iron
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
-    version: rolling
+    version: iron
   ros/kdl_parser:
     type: git
     url: https://github.com/ros/kdl_parser.git
-    version: rolling
+    version: iron
   ros/pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: rolling
+    version: iron
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
-    version: rolling
+    version: iron
   ros/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
-    version: rolling
+    version: iron
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: rolling
+    version: iron
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: rolling
+    version: iron
   ros/urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
-    version: master
+    version: iron
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
-    version: master
+    version: iron
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: rolling
+    version: iron
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: rolling
+    version: iron
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
-    version: rolling
+    version: iron
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: rolling
+    version: iron
   ros2/eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
-    version: rolling
+    version: iron
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: rolling
+    version: iron
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: rolling
+    version: iron
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: rolling
+    version: iron
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: rolling
+    version: iron
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: rolling
+    version: iron
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: rolling
+    version: iron
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: rolling
+    version: iron
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
-    version: rolling
+    version: iron
   ros2/orocos_kdl_vendor:
     type: git
     url: https://github.com/ros2/orocos_kdl_vendor.git
-    version: rolling
+    version: iron
   ros2/performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
-    version: rolling
+    version: iron
   ros2/pybind11_vendor:
     type: git
     url: https://github.com/ros2/pybind11_vendor.git
-    version: rolling
+    version: iron
   ros2/python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git
-    version: rolling
+    version: iron
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: rolling
+    version: iron
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: rolling
+    version: iron
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: rolling
+    version: iron
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: rolling
+    version: iron
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: rolling
+    version: iron
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: rolling
+    version: iron
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: rolling
+    version: iron
   ros2/realtime_support:
     type: git
     url: https://github.com/ros2/realtime_support.git
-    version: rolling
+    version: iron
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: rolling
+    version: iron
   ros2/rmw_connextdds:
     type: git
     url: https://github.com/ros2/rmw_connextdds.git
-    version: rolling
+    version: iron
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: rolling
+    version: iron
   ros2/rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
-    version: rolling
+    version: iron
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: rolling
+    version: iron
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: rolling
+    version: iron
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: rolling
+    version: iron
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: rolling
+    version: iron
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
-    version: rolling
+    version: iron
   ros2/ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git
-    version: rolling
+    version: iron
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: rolling
+    version: iron
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: rolling
+    version: iron
   ros2/rosidl_core:
     type: git
     url: https://github.com/ros2/rosidl_core.git
-    version: rolling
+    version: iron
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: rolling
+    version: iron
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: rolling
+    version: iron
   ros2/rosidl_dynamic_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_dynamic_typesupport
-    version: rolling
+    version: iron
   ros2/rosidl_dynamic_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps
-    version: rolling
+    version: iron
   ros2/rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: rolling
+    version: iron
   ros2/rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
-    version: rolling
+    version: iron
   ros2/rosidl_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_typesupport.git
-    version: rolling
+    version: iron
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: rolling
+    version: iron
   ros2/rpyutils:
     type: git
     url: https://github.com/ros2/rpyutils.git
-    version: rolling
+    version: iron
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: rolling
+    version: iron
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
-    version: rolling
+    version: iron
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: rolling
+    version: iron
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git
-    version: rolling
+    version: iron
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
-    version: rolling
+    version: iron
   ros2/tinyxml2_vendor:
     type: git
     url: https://github.com/ros2/tinyxml2_vendor.git
-    version: rolling
+    version: iron
   ros2/tinyxml_vendor:
     type: git
     url: https://github.com/ros2/tinyxml_vendor.git
-    version: rolling
+    version: iron
   ros2/tlsf:
     type: git
     url: https://github.com/ros2/tlsf.git
-    version: rolling
+    version: iron
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: rolling
+    version: iron
   ros2/urdf:
     type: git
     url: https://github.com/ros2/urdf.git
-    version: rolling
+    version: iron
   ros2/yaml_cpp_vendor:
     type: git
     url: https://github.com/ros2/yaml_cpp_vendor.git
-    version: rolling
+    version: iron


### PR DESCRIPTION
I branched off `rolling` of this pkg to create `iron` without making any other changes. This PR updates the `ros2.repos` file in `iron` branch with the actual branches for this distro.

Notes:
* `rolling` uses `Fast-CDR/master`. I changed this to `Fast-CDR/v.1.0.27` which is the latest release. Is this fine or should we leave it at `master`?
* `osrf/osrf_pycommon` is still set to `master` while `osrf/osrf_testing_tools_cpp` has an `iron` branch which was branched from `rolling`.
* `ros/urdfdom` and `ros/urdfdom_headers` are set to `iron` which was created by branching off `master` resp. 