### PR TITLE
Humble release bump rosbag2

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -334,7 +334,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.15.5
+    version: 0.15.6
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git


### PR DESCRIPTION
Follow up from https://github.com/ros/rosdistro/pull/37487

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18912)](http://ci.ros2.org/job/ci_linux/18912/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=13447)](http://ci.ros2.org/job/ci_linux-aarch64/13447/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=19668)](http://ci.ros2.org/job/ci_windows/19668/)
* RHEL [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=428)](http://ci.ros2.org/job/ci_linux-rhel/428/)

Packaging:
* https://ci.ros2.org/view/packaging/job/packaging_linux/3063/
* https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/2419/
* https://ci.ros2.org/view/packaging/job/packaging_linux-rhel/1561/
* https://ci.ros2.org/view/packaging/job/packaging_windows/2890/
* https://ci.ros2.org/view/packaging/job/packaging_windows_debug/1849/