### PR TITLE
Update to ament_cmake 2.0.3

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.0.2
+    version: 2.0.3
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git


### PR DESCRIPTION
This release contains critical fixes for the `ament_cmake_vendor_package` package.