### PR TITLE
Add git extension to rosidl_dynamic_typesupport repositories.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -353,11 +353,11 @@ repositories:
     version: rolling
   ros2/rosidl_dynamic_typesupport:
     type: git
-    url: https://github.com/ros2/rosidl_dynamic_typesupport
+    url: https://github.com/ros2/rosidl_dynamic_typesupport.git
     version: rolling
   ros2/rosidl_dynamic_typesupport_fastrtps:
     type: git
-    url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps
+    url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
     version: rolling
   ros2/rosidl_python:
     type: git


### PR DESCRIPTION
That just makes it consistent with everything else.