### PR TITLE
Better default ReadMe for ROS 2 repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Looking to get started with ROS? Our [installation guide is here](https://www.ro
 * [ROS Discord Server](https://discord.com/servers/open-robotics-1077825543698927656)
 * [Robotics Stack Exchange](https://robotics.stackexchange.com/) (preferred ROS support forum).
 * [Official ROS Videos](https://vimeo.com/osrfoundation)
-* [ROSCon,](https://roscon.ros.org) our yearly developer conference. 
+* [ROSCon](https://roscon.ros.org), our yearly developer conference. 
 * Cite ROS 2 in academic work using [DOI: 10.1126/scirobotics.abm6074](https://www.science.org/doi/10.1126/scirobotics.abm6074) 
 * [ROS 1 Wiki](https://wiki.ros.org/)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Looking to get started with ROS? Our [installation guide is here](https://www.ro
 * [Official ROS Videos](https://vimeo.com/osrfoundation)
 * [ROSCon](https://roscon.ros.org), our yearly developer conference. 
 * Cite ROS 2 in academic work using [DOI: 10.1126/scirobotics.abm6074](https://www.science.org/doi/10.1126/scirobotics.abm6074) 
-* [ROS 1 Wiki](https://wiki.ros.org/)
 
 ## Developer Resources
 * [ROS 2 Documentation](https://docs.ros.org/)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-Documentation is at https://docs.ros.org
+# About 
+The Robot Operating System (ROS) is a set of software libraries and tools that help you build robot applications. From drivers to state-of-the-art algorithms, and with powerful developer tools, ROS has what you need for your next robotics project. And it's all open source. Full project details on [ROS.org](https://ros.org/)
+
+# Getting Started 
+Looking to get started with ROS? Our [installation guide is here](https://www.ros.org/blog/getting-started/). Once you've installed ROS start by learning some [basic concepts](https://docs.ros.org/en/rolling/Concepts/Basic.html) and take a look at our [beginner tutorials](https://docs.ros.org/en/rolling/Tutorials/Beginner-CLI-Tools.html).
+
+# Join the [ROS](https://ros.org/) Community
+
+## Community Resources
+
+* [ROS Discussion Forum](https://discourse.ros.org/)
+* [ROS Discord Server](https://discord.com/servers/open-robotics-1077825543698927656)
+* [Robotics Stack Exchange](https://robotics.stackexchange.com/) (preferred ROS support forum).
+* [Official ROS Videos](https://vimeo.com/osrfoundation)
+* [ROSCon,](https://roscon.ros.org) our yearly developer conference. 
+* Cite ROS 2 in academic work using [DOI: 10.1126/scirobotics.abm6074](https://www.science.org/doi/10.1126/scirobotics.abm6074) 
+* [ROS 1 Wiki](https://wiki.ros.org/)
+
+## Developer Resources
+* [ROS 2 Documentation](https://docs.ros.org/)
+* [ROS Package Python APIs](https://docs.ros.org/en/rolling/p/)
+* [ROS Package C++ APIs](https://docs.ros.org/en/api/)
+* [ROS Package Index](https://index.ros.org/)
+* [ROS on Docker Hub](https://hub.docker.com/_/ros/)
+* [ROS Resource Status Page](https://status.openrobotics.org/)
+* [REP-2000:](https://ros.org/reps/rep-2000.html) ROS 2 Releases and Target Platforms
+
+## Project Resources
+* [Purchase ROS Swag](https://spring.ros.org/)
+* [Information about the ROS Trademark](https://www.ros.org/blog/media/)
+* On Social Media
+  * [Open Robotics on LinkedIn](https://www.linkedin.com/company/open-source-robotics-foundation)
+  * [Open Robotics on Twitter](https://twitter.com/OpenRoboticsOrg)
+  * [ROS.org on Twitter](https://twitter.com/ROSOrg)
+
+ROS is made possible through the generous support of open source contributors and the non-profit [Open Source Robotics Foundation (OSRF)](https://www.openrobotics.org/). Tax deductible donations to the OSRF can be [made here.](https://donorbox.org/support-open-robotics?utm_medium=qrcode&utm_source=qrcode)
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Looking to get started with ROS? Our [installation guide is here](https://www.ro
 * [ROS Package Index](https://index.ros.org/)
 * [ROS on Docker Hub](https://hub.docker.com/_/ros/)
 * [ROS Resource Status Page](https://status.openrobotics.org/)
-* [REP-2000:](https://ros.org/reps/rep-2000.html) ROS 2 Releases and Target Platforms
+* [REP-2000](https://ros.org/reps/rep-2000.html): ROS 2 Releases and Target Platforms
 
 ## Project Resources
 * [Purchase ROS Swag](https://spring.ros.org/)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # About 
-The Robot Operating System (ROS) is a set of software libraries and tools that help you build robot applications. From drivers to state-of-the-art algorithms, and with powerful developer tools, ROS has what you need for your next robotics project. And it's all open source. Full project details on [ROS.org](https://ros.org/)
+The Robot Operating System (ROS) is a set of software libraries and tools that help you build robot applications.
+From drivers to state-of-the-art algorithms, and with powerful developer tools, ROS has what you need for your next robotics project.
+And it's all open source.
+Full project details on [ROS.org](https://ros.org/)
 
 # Getting Started 
-Looking to get started with ROS? Our [installation guide is here](https://www.ros.org/blog/getting-started/). Once you've installed ROS start by learning some [basic concepts](https://docs.ros.org/en/rolling/Concepts/Basic.html) and take a look at our [beginner tutorials](https://docs.ros.org/en/rolling/Tutorials/Beginner-CLI-Tools.html).
+Looking to get started with ROS?
+Our [installation guide is here](https://www.ros.org/blog/getting-started/).
+Once you've installed ROS start by learning some [basic concepts](https://docs.ros.org/en/rolling/Concepts/Basic.html) and take a look at our [beginner tutorials](https://docs.ros.org/en/rolling/Tutorials/Beginner-CLI-Tools.html).
 
 # Join the ROS Community
 
@@ -31,4 +36,5 @@ Looking to get started with ROS? Our [installation guide is here](https://www.ro
   * [Open Robotics on Twitter](https://twitter.com/OpenRoboticsOrg)
   * [ROS.org on Twitter](https://twitter.com/ROSOrg)
 
-ROS is made possible through the generous support of open source contributors and the non-profit [Open Source Robotics Foundation (OSRF)](https://www.openrobotics.org/). Tax deductible donations to the OSRF can be [made here.](https://donorbox.org/support-open-robotics?utm_medium=qrcode&utm_source=qrcode)
+ROS is made possible through the generous support of open source contributors and the non-profit [Open Source Robotics Foundation (OSRF)](https://www.openrobotics.org/).
+Tax deductible donations to the OSRF can be [made here.](https://donorbox.org/support-open-robotics?utm_medium=qrcode&utm_source=qrcode)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Robot Operating System (ROS) is a set of software libraries and tools that h
 # Getting Started 
 Looking to get started with ROS? Our [installation guide is here](https://www.ros.org/blog/getting-started/). Once you've installed ROS start by learning some [basic concepts](https://docs.ros.org/en/rolling/Concepts/Basic.html) and take a look at our [beginner tutorials](https://docs.ros.org/en/rolling/Tutorials/Beginner-CLI-Tools.html).
 
-# Join the [ROS](https://ros.org/) Community
+# Join the ROS Community
 
 ## Community Resources
 

--- a/README.md
+++ b/README.md
@@ -32,4 +32,3 @@ Looking to get started with ROS? Our [installation guide is here](https://www.ro
   * [ROS.org on Twitter](https://twitter.com/ROSOrg)
 
 ROS is made possible through the generous support of open source contributors and the non-profit [Open Source Robotics Foundation (OSRF)](https://www.openrobotics.org/). Tax deductible donations to the OSRF can be [made here.](https://donorbox.org/support-open-robotics?utm_medium=qrcode&utm_source=qrcode)
-

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Looking to get started with ROS? Our [installation guide is here](https://www.ro
 
 ## Developer Resources
 * [ROS 2 Documentation](https://docs.ros.org/)
-* [ROS Package Python APIs](https://docs.ros.org/en/rolling/p/)
-* [ROS Package C++ APIs](https://docs.ros.org/en/api/)
+* [ROS Package API reference](https://docs.ros.org/en/rolling/p/)
 * [ROS Package Index](https://index.ros.org/)
 * [ROS on Docker Hub](https://hub.docker.com/_/ros/)
 * [ROS Resource Status Page](https://status.openrobotics.org/)


### PR DESCRIPTION
Strawman proposal for a more comprehensive README.md for most of the core ROS 2 repositories.  My goal with this readme is to quickly summarize most of the core community resources for new ROS users. 

Once we converge on a final proposal my intent is to re-use this text at the end of most of the ROS 2 repos.