### PR TITLE
Set eProsima products branches

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -30,11 +30,11 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: master
+    version: 1.1.x
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: master
+    version: 2.11.x
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
eProsima/Fast-CDR#156 has just been merged increasing Fast CDR major version as its public API has been changed. Consequently, if ROS 2 rolling keeps using eProsima's master branches, compilation will be broken until Fast DDS release is done. This PR fixes Fast CDR version to the 1.1.x branch and Fast DDS to the 2.11.x branch.