### PR TITLE
Bump versions for Iron Patch 2

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.14.1
+    version: 0.14.2
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: 2.10.1
+    version: 2.10.2
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -66,7 +66,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: 4.2.0
+    version: 4.2.2
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -106,7 +106,7 @@ repositories:
   ros-visualization/rqt_bag:
     type: git
     url: https://github.com/ros-visualization/rqt_bag.git
-    version: 1.3.3
+    version: 1.3.4
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
@@ -222,7 +222,7 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.31.4
+    version: 0.31.5
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
@@ -262,7 +262,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 6.0.2
+    version: 6.0.3
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -274,11 +274,11 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 21.0.2
+    version: 21.0.3
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 4.1.2
+    version: 4.1.3
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
@@ -322,7 +322,7 @@ repositories:
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.25.2
+    version: 0.25.3
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -334,7 +334,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.22.2
+    version: 0.22.3
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -354,7 +354,7 @@ repositories:
   ros2/rosidl_dynamic_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_dynamic_typesupport
-    version: 0.0.3
+    version: 0.0.4
   ros2/rosidl_dynamic_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps
@@ -382,7 +382,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 12.4.1
+    version: 12.4.4
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -402,7 +402,7 @@ repositories:
   ros2/tinyxml2_vendor:
     type: git
     url: https://github.com/ros2/tinyxml2_vendor.git
-    version: 0.8.2
+    version: 0.8.3
   ros2/tinyxml_vendor:
     type: git
     url: https://github.com/ros2/tinyxml_vendor.git


### PR DESCRIPTION
CI job created using https://raw.githubusercontent.com/ros2/ros2/yadu/iron-patch-2/ros2.repos

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19488)](http://ci.ros2.org/job/ci_linux/19488/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14008)](http://ci.ros2.org/job/ci_linux-aarch64/14008/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20206)](http://ci.ros2.org/job/ci_windows/20206/)
* RHEL-9 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=469)](https://ci.ros2.org/view/All/job/ci_linux-rhel/469/)

Will run packaging jobs after CI passes.