### PR TITLE
Humble release versions 2023-09-25

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 0.10.4
+    version: 0.10.3
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
@@ -58,7 +58,7 @@ repositories:
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: 2.1.4
+    version: 2.0.2
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.12.7
+    version: 0.12.8
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.6.4
+    version: v2.6.6
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -42,7 +42,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 0.9.1
+    version: 0.10.4
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
@@ -58,7 +58,7 @@ repositories:
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: 2.1.3
+    version: 2.1.4
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
@@ -66,7 +66,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: 3.1.5
+    version: 3.1.7
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -222,7 +222,7 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.25.3
+    version: 0.25.4
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
@@ -230,7 +230,7 @@ repositories:
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.19.5
+    version: 0.19.6
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -262,7 +262,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 5.3.4
+    version: 5.3.5
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -274,11 +274,11 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 16.0.5
+    version: 16.0.6
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 3.3.9
+    version: 3.3.10
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
@@ -310,7 +310,7 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 6.2.3
+    version: 6.2.4
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
@@ -334,7 +334,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.15.7
+    version: 0.15.8
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -370,7 +370,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 11.2.6
+    version: 11.2.8
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git


### PR DESCRIPTION

Run with `clalancette/revert-domain-id` CI branch:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19546)](http://ci.ros2.org/job/ci_linux/19546/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14060)](http://ci.ros2.org/job/ci_linux-aarch64/14060/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20263)](http://ci.ros2.org/job/ci_windows/20263/)
* RHEL [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=474)](http://ci.ros2.org/job/ci_linux-rhel/474/)

https://ci.ros2.org/view/packaging/job/packaging_linux/3173/
https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/2537/
https://ci.ros2.org/view/packaging/job/packaging_linux-rhel/1672/
https://ci.ros2.org/view/packaging/job/packaging_windows/2996/
https://ci.ros2.org/view/packaging/job/packaging_windows_debug/1955/

<details><summary>Past runs</summary>

Run 1
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19530)](http://ci.ros2.org/job/ci_linux/19530/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14050)](http://ci.ros2.org/job/ci_linux-aarch64/14050/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20250)](http://ci.ros2.org/job/ci_windows/20250/)
* RHEL [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=470)](http://ci.ros2.org/job/ci_linux-rhel/470/)

Run 2
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19533)](http://ci.ros2.org/job/ci_linux/19533/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14052)](http://ci.ros2.org/job/ci_linux-aarch64/14052/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20253)](http://ci.ros2.org/job/ci_windows/20253/)
* RHEL [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=473)](http://ci.ros2.org/job/ci_linux-rhel/473/)

https://ci.ros2.org/view/packaging/job/packaging_linux/3170/
https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/2534/
https://ci.ros2.org/view/packaging/job/packaging_linux-rhel/1668/
https://ci.ros2.org/view/packaging/job/packaging_windows/2993/
https://ci.ros2.org/view/packaging/job/packaging_windows_debug/1952/

</details>