### PR TITLE
Remove tinyxml_vendor.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -403,10 +403,6 @@ repositories:
     type: git
     url: https://github.com/ros2/tinyxml2_vendor.git
     version: rolling
-  ros2/tinyxml_vendor:
-    type: git
-    url: https://github.com/ros2/tinyxml_vendor.git
-    version: rolling
   ros2/tlsf:
     type: git
     url: https://github.com/ros2/tlsf.git


### PR DESCRIPTION
Now that urdfdom no longer requires it, we shouldn't need it at all.

Still a draft until I run CI and verify that it is truly not needed anymore.