### PR TITLE
Bump Fast DDS to 2.13.x

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: 2.11.x
+    version: 2.13.x
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
Fast DDS 2.11.x will reach end-of-life before the end of this month.

Bumping to 2.13.x, which will keep receiving fixes, and also has interesting features like configuring thread attributes, or expanding environment variables in the XML profiles.