### PR TITLE
Humble release versions 2024-01-26

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 0.10.4
+    version: 0.10.3
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
@@ -58,7 +58,7 @@ repositories:
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: 2.1.4
+    version: 2.0.2
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 0.10.3
+    version: 0.10.4
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 1.3.6
+    version: 1.3.7
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.12.9
+    version: 0.12.10
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -42,11 +42,11 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 0.10.3
+    version: 0.10.4
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
-    version: v2.0.3
+    version: v2.0.5
   ignition/ignition_cmake2_vendor:
     type: git
     url: https://github.com/ignition-release/ignition_cmake2_vendor.git
@@ -58,7 +58,7 @@ repositories:
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: 2.0.2
+    version: 2.1.4
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
@@ -66,7 +66,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: 3.1.7
+    version: 3.1.8
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -94,11 +94,11 @@ repositories:
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: 2.2.2
+    version: 2.2.3
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
-    version: 1.1.5
+    version: 1.1.6
   ros-visualization/rqt_action:
     type: git
     url: https://github.com/ros-visualization/rqt_action.git
@@ -174,7 +174,7 @@ repositories:
   ros/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
-    version: 3.0.2
+    version: 3.0.3
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
@@ -230,7 +230,7 @@ repositories:
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.19.6
+    version: 0.19.7
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -262,7 +262,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 5.3.6
+    version: 5.3.7
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -274,7 +274,7 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 16.0.7
+    version: 16.0.8
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
@@ -310,7 +310,7 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 6.2.5
+    version: 6.2.6
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
@@ -322,7 +322,7 @@ repositories:
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.18.7
+    version: 0.18.8
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -334,7 +334,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.15.8
+    version: 0.15.9
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -370,7 +370,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 11.2.9
+    version: 11.2.10
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git


### PR DESCRIPTION
- [x] Merge in https://github.com/ros2/rosbag2/pull/1551

Note, this is actually patch release 7. I misremembered when creating the branch. I can change it if it'd be good to do.

---

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20136)](http://ci.ros2.org/job/ci_linux/20136/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14574)](http://ci.ros2.org/job/ci_linux-aarch64/14574/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20847)](http://ci.ros2.org/job/ci_windows/20847/)
* RHEL [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=562)](https://ci.ros2.org/job/ci_linux-rhel/562/)

https://ci.ros2.org/view/packaging/job/packaging_linux/3313/
https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/2671/
https://ci.ros2.org/view/packaging/job/packaging_linux-rhel/1815/
https://ci.ros2.org/view/packaging/job/packaging_windows/3126/
https://ci.ros2.org/view/packaging/job/packaging_windows_debug/2086/