### PR TITLE
Remove python_cmake_module from ros2.repos.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -263,10 +263,6 @@ repositories:
     type: git
     url: https://github.com/ros2/pybind11_vendor.git
     version: rolling
-  ros2/python_cmake_module:
-    type: git
-    url: https://github.com/ros2/python_cmake_module.git
-    version: rolling
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git


### PR DESCRIPTION
This PR aims to remove `python_cmake_module` from the core ROS 2 repositories.

The basic idea behind this is that `python_cmake_module` is an unnecessary indirection to `find_package(Python3)`, which is a standard CMake feature.  So we may as well remove it and save that additional layer of indirection.

While we are doing this, we also notice that we can support venvs in ROS 2 much better by taking advantage of some newer features of `find_package(Python3)`.  In particular, we can set [CMP0094](https://cmake.org/cmake/help/latest/policy/CMP0094.html), which sets `Python3_FIND_STRATEGY` to `LOCATION`.  In short, this means that `find_package(Python3)` will stop searching after it finds the first python3 binary it can.

However, `find_package(Python3)`, at least on Linux, will attempt to find the most specific version it can by default.  That means that if both `python3.11` and `python3` are on the PATH, it will by default choose `python3.11`.  We can also control *that* behavior by setting [Python3_FIND_UNVERSIONED_NAMES](https://cmake.org/cmake/help/latest/module/FindPython3.html#hints) to `FIRST`.

The end result of all of this is that venvs on Linux should work properly, as long as the venv is activated.  On Windows, due to different logic, this always worked properly.  If all else fails, the user can always pass `--cmake-args -DPython3_EXECUTABLE=/path/to/python3`, which will forcibly set the path to the python executable.

Given the complexity of Python packaging, I don't expect it will fix all related problems, but it should improve many of our venv issues, like https://github.com/ros2/ros2cli/issues/879 , https://github.com/ament/ament_cmake/issues/502 , https://github.com/ros2/ros2/issues/1519 , https://github.com/ros2/ros2/issues/1094 , and https://github.com/ros2/ros2/issues/1430 .

Also note that this is *not* backportable to Humble, since it requires CMake 3.20 and Humble has to support CMake versions older than that.  There we are using a simpler version of this, in https://github.com/ros2/geometry2/pull/650 and https://github.com/ament/ament_cmake/pull/507 .  This might be backportable to Iron, but we'll have to see.

Note that this is a draft because we need to get all of the dependent PRs in first, and I still have to write up the documentation and CI code for this.