### PR TITLE
Humble release versions 2024-02-22

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -98,7 +98,7 @@ repositories:
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
-    version: 1.1.6
+    version: 1.1.7
   ros-visualization/rqt_action:
     type: git
     url: https://github.com/ros-visualization/rqt_action.git
@@ -110,7 +110,7 @@ repositories:
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: 2.0.2
+    version: 2.0.3
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
@@ -226,7 +226,7 @@ repositories:
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 1.0.4
+    version: 1.0.5
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
@@ -278,15 +278,15 @@ repositories:
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 3.3.11
+    version: 3.3.12
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 2.4.1
+    version: 2.4.2
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: 5.1.4
+    version: 5.1.5
   ros2/realtime_support:
     type: git
     url: https://github.com/ros2/realtime_support.git
@@ -370,7 +370,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 11.2.10
+    version: 11.2.11
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 1.3.7
+    version: 1.3.8
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.6.6
+    version: v2.6.7
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -222,7 +222,7 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.25.5
+    version: 0.25.6
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
@@ -322,7 +322,7 @@ repositories:
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.18.8
+    version: 0.18.9
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git


### PR DESCRIPTION
CI:
https://ci.ros2.org/job/ci_linux/20331/ (green)
https://ci.ros2.org/job/ci_linux-aarch64/14745/ (green)
https://ci.ros2.org/job/ci_windows/21078/ (green)
https://ci.ros2.org/job/ci_linux-rhel/584/ (yellow)

Packaging:
https://ci.ros2.org/view/packaging/job/packaging_linux/3344/
https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/2701/
https://ci.ros2.org/view/packaging/job/packaging_linux-rhel/1842/
https://ci.ros2.org/view/packaging/job/packaging_windows/3156/
https://ci.ros2.org/view/packaging/job/packaging_windows_debug/2118/