### PR TITLE
Pin Fast-DDS to the last known working version.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: 2.13.x
+    version: f0df89d27cb4522b1e896d411210e364ce9883a6
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
The latest version as of 2024-02-21 breaks many tests.

See any of the nightly ROS 2 builds, like https://ci.ros2.org/view/nightly/job/nightly_linux_release/2989/

@EduPonz @MiguelCompany FYI