### PR TITLE
Revert "Pin Fast-DDS to the last known working version."

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: f0df89d27cb4522b1e896d411210e364ce9883a6
+    version: 2.13.x
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
This reverts ros2/ros2#1527, since https://github.com/eProsima/Fast-DDS/pull/4417 has been merged and should have fixed the original issue