### PR TITLE
Upgrade Fast CDR to 2.2.x

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: 1.1.x
+    version: 2.2.x
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
This PR updates Fast CDR to 2.2.x

The following PRs update the dependent packages to deal with the API breaks from Fast CDR v1 to v2,
and should be merged along with this one:

- ros2/rosidl_typesupport_fastrtps#114
- ros2/rmw_fastrtps#746
- ros2/rmw_connextdds#141

For simplicity, I have prepared [this repos file](https://gist.github.com/MiguelCompany/bbe57781907e23da2c837c13db28f209#file-support-fastcdr-2-repos) with which we have tested the changes