### PR TITLE
Enable using cloned repo as workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore default names for colcon created folders
+build
+install
+log
+
+# Ignore everything in src except a .gitkeep file
+src/*
+!src/.gitkeep


### PR DESCRIPTION
The guide
http://docs.ros.org/en/rolling/Installation/Maintaining-a-Source-Checkout.html explains how to manually download the ros2.repos file to maintain a source checkout. Another way to maintain a source checkout is to clone this repository and `git pull` updates to the repos file.

This PR makes that alternative a little more convenient. The .gitignore file ignores the default names of folders created by colcon, and the src folder is created with just a .gitkeep file and the rest ignored so that `git status` on the repository doesn't try to show the status of subfolders of `src`.