### PR TITLE
Switch to new gazebo vendor packages.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -47,13 +47,17 @@ repositories:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
     version: release_2.0
-  gazebo-release/gz_cmake2_vendor:
+  gazebo-release/gz_cmake_vendor:
     type: git
-    url: https://github.com/gazebo-release/gz_cmake2_vendor.git
+    url: https://github.com/gazebo-release/gz_cmake_vendor.git
     version: rolling
-  gazebo-release/gz_math6_vendor:
+  gazebo-release/gz_math_vendor:
     type: git
-    url: https://github.com/gazebo-release/gz_math6_vendor.git
+    url: https://github.com/gazebo-release/gz_math_vendor.git
+    version: rolling
+  gazebo-release/gz_utils_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_utils_vendor.git
     version: rolling
   osrf/osrf_pycommon:
     type: git


### PR DESCRIPTION
These are the ones we'll be using going forward.

@azeey @ahcorde I could review of this from both of you.

This needs to be merged simultaneously with https://github.com/ros2/rviz/pull/1177