### PR TITLE
Jazzy patch release versions  2024-07-01

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.14.0
+    version: v2.14.1
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.5.0
+    version: 2.5.1
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.17.0
+    version: 0.17.1
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -30,7 +30,7 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.2.1
+    version: v2.2.2
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
@@ -70,7 +70,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: 5.1.2
+    version: 5.1.4
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -78,7 +78,7 @@ repositories:
   ros-perception/point_cloud_transport:
     type: git
     url: https://github.com/ros-perception/point_cloud_transport.git
-    version: 4.0.0
+    version: 4.0.2
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
@@ -90,7 +90,7 @@ repositories:
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: 1.7.2
+    version: 1.7.3
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
@@ -178,7 +178,7 @@ repositories:
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
-    version: 3.4.2
+    version: 3.4.3
   ros/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
@@ -214,7 +214,7 @@ repositories:
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: 0.33.3
+    version: 0.33.4
   ros2/eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
@@ -226,11 +226,11 @@ repositories:
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: 0.19.3
+    version: 0.19.4
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.36.3
+    version: 0.36.4
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
@@ -282,7 +282,7 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 28.1.2
+    version: 28.1.3
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
@@ -318,15 +318,15 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 8.4.0
+    version: 8.4.1
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 2.15.2
+    version: 2.15.3
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: 8.2.0
+    version: 8.2.1
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
@@ -342,11 +342,11 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.26.3
+    version: 0.26.4
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 4.6.2
+    version: 4.6.3
   ros2/rosidl_core:
     type: git
     url: https://github.com/ros2/rosidl_core.git
@@ -390,7 +390,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 14.1.1
+    version: 14.1.2
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -398,7 +398,7 @@ repositories:
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: 0.13.1
+    version: 0.13.2
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.5.1
+    version: 2.5.2
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -42,7 +42,7 @@ repositories:
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 0.10.4
+    version: 0.10.5
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git


### PR DESCRIPTION
First Jazzy patch release :tada: 

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=21348)](http://ci.ros2.org/job/ci_linux/21348/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=15662)](http://ci.ros2.org/job/ci_linux-aarch64/15662/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=22090)](http://ci.ros2.org/job/ci_windows/22090/)
* RHEL [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=866)](https://ci.ros2.org/job/ci_linux-rhel/866/)

Packaging:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=559)](http://ci.ros2.org/job/ci_packaging_linux/559/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=107)](http://ci.ros2.org/job/ci_packaging_linux-aarch64/107/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=228)](http://ci.ros2.org/job/ci_packaging_windows/228/)
* RHEL [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-rhel&build=65)](https://ci.ros2.org/job/ci_packaging_linux-rhel/65/)