### PR TITLE
Bump versions for Iron Patch Release 6

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.0.5
+    version: 2.0.6
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.14.3
+    version: 0.14.4
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.10.3
+    version: v2.10.4
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -106,7 +106,7 @@ repositories:
   ros-visualization/rqt_bag:
     type: git
     url: https://github.com/ros-visualization/rqt_bag.git
-    version: 1.3.4
+    version: 1.3.5
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
@@ -114,7 +114,7 @@ repositories:
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: 1.4.2
+    version: 1.4.3
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git
@@ -170,7 +170,7 @@ repositories:
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
-    version: 3.2.2
+    version: 3.2.3
   ros/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
@@ -198,7 +198,7 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 5.0.0
+    version: 5.0.1
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
@@ -206,7 +206,7 @@ repositories:
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: 0.27.1
+    version: 0.27.2
   ros2/eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
@@ -218,15 +218,15 @@ repositories:
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: 0.18.0
+    version: 0.18.1
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.31.6
+    version: 0.31.7
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 2.0.3
+    version: 2.0.4
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
@@ -262,7 +262,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 6.0.5
+    version: 6.0.6
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -274,15 +274,15 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 21.0.6
+    version: 21.0.7
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 4.1.5
+    version: 4.1.6
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 2.6.3
+    version: 2.6.4
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
@@ -310,19 +310,19 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 7.1.3
+    version: 7.1.4
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 2.12.0
+    version: 2.12.1
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: 6.3.1
+    version: 6.3.2
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.25.6
+    version: 0.25.7
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -334,7 +334,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.22.6
+    version: 0.22.7
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -382,7 +382,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 12.4.7
+    version: 12.4.8
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git


### PR DESCRIPTION
This PR updates release versions for Iron.

I still need to tag and bloom rosbag2 but i've updated the version here in advance.
* https://github.com/ros2/rosbag2/pull/1741

Will run CI jobs after rosbag2 is bumped and this PR is approved. 