### PR TITLE
Jazzy patch release 2024-12-23 

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.2.6
+    version: v2.2.5
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -46,7 +46,7 @@ repositories:
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
-    version: v2.0.5
+    version: v2.0.6
   gazebo-release/gz_cmake_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_cmake_vendor.git
@@ -230,7 +230,7 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.36.6
+    version: 0.36.7
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
@@ -382,7 +382,7 @@ repositories:
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: 3.6.0
+    version: 3.6.1
   ros2/rpyutils:
     type: git
     url: https://github.com/ros2/rpyutils.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.5.2
+    version: 2.5.3
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -30,11 +30,11 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.2.4
+    version: v2.2.6
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.14.1
+    version: v2.14.4
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -54,7 +54,7 @@ repositories:
   gazebo-release/gz_math_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_math_vendor.git
-    version: 0.0.6
+    version: 0.0.7
   gazebo-release/gz_utils_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_utils_vendor.git
@@ -62,7 +62,7 @@ repositories:
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: 2.1.4
+    version: 2.1.5
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
@@ -70,7 +70,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: 5.1.4
+    version: 5.1.5
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -78,7 +78,7 @@ repositories:
   ros-perception/point_cloud_transport:
     type: git
     url: https://github.com/ros-perception/point_cloud_transport.git
-    version: 4.0.2
+    version: 4.0.3
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
@@ -90,7 +90,7 @@ repositories:
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: 1.7.3
+    version: 1.7.4
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
@@ -102,7 +102,7 @@ repositories:
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: 2.7.4
+    version: 2.7.5
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
@@ -158,7 +158,7 @@ repositories:
   ros-visualization/rqt_topic:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
-    version: 1.7.2
+    version: 1.7.3
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
@@ -230,15 +230,15 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.36.4
+    version: 0.36.6
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 3.4.2
+    version: 3.4.3
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.26.5
+    version: 0.26.6
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -246,7 +246,7 @@ repositories:
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: 4.11.2
+    version: 4.11.3
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
@@ -278,19 +278,19 @@ repositories:
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: 3.1.0
+    version: 3.1.1
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 28.1.5
+    version: 28.1.6
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 7.1.2
+    version: 7.1.3
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 2.11.0
+    version: 2.11.1
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
@@ -322,15 +322,15 @@ repositories:
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 2.15.3
+    version: 2.15.4
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: 8.2.2
+    version: 8.2.3
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.32.1
+    version: 0.32.2
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -342,11 +342,11 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.26.5
+    version: 0.26.6
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 4.6.4
+    version: 4.6.5
   ros2/rosidl_core:
     type: git
     url: https://github.com/ros2/rosidl_core.git
@@ -390,7 +390,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 14.1.5
+    version: 14.1.6
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git


### PR DESCRIPTION
Jazzy patch release: https://discourse.ros.org/t/preparing-for-jazzy-sync-and-patch-release-2024-12-23/

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=22313)](https://ci.ros2.org/job/ci_linux/22313/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=16576)](https://ci.ros2.org/job/ci_linux-aarch64/16576/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=23105)](https://ci.ros2.org/job/ci_windows/23105/)
* RHEL [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=1845)](https://ci.ros2.org/job/ci_linux-rhel/1845/)

Packaging:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=565)](https://ci.ros2.org/job/ci_packaging_linux/565/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=111)](https://ci.ros2.org/job/ci_packaging_linux-aarch64/111/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=236)](https://ci.ros2.org/job/ci_packaging_windows/236/)
* RHEL [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-rhel&build=71)](https://ci.ros2.org/job/ci_packaging_linux-rhel/71/)