### PR TITLE
Update Fast DDS to 3.2.x

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: 3.1.x
+    version: 3.2.x
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: 2.2.x
+    version: 2.3.x
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
As you can see [here](https://github.com/eProsima/Fast-DDS/blob/master/RELEASE_SUPPORT.md#eprosima-fast-dds-currently-supported-versions-and-their-support-cycles), Fast DDS next LTS version will be 3.2.x (currently a mirror of the master branch).
