### PR TITLE
Update Fast DDS to 3.1.x

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v3.1.0
+    version: 3.1.x
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
Just what the title says, change Fast DDS from fixed v3.1.0 to 3.1.x, so changes there are tested before releasing v3.1.2