### PR TITLE
Update fast-dds minor version

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v3.1.0
+    version: v3.1.2
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
https://github.com/eProsima/Fast-DDS/releases
main changes:
Fix CVE-2025-24807
fix compilation




.