### PR TITLE
Humble release versions

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.12.11
+    version: 0.12.12
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -66,7 +66,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: 3.1.9
+    version: 3.1.11
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -94,7 +94,7 @@ repositories:
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: 2.2.3
+    version: 2.2.4
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
@@ -122,7 +122,7 @@ repositories:
   ros-visualization/rqt_plot:
     type: git
     url: https://github.com/ros-visualization/rqt_plot.git
-    version: 1.1.2
+    version: 1.1.4
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
@@ -166,11 +166,11 @@ repositories:
   ros/pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: 5.1.0
+    version: 5.1.1
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
-    version: 3.1.2
+    version: 3.1.3
   ros/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
@@ -198,7 +198,7 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 4.2.4
+    version: 4.8.0
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
@@ -222,15 +222,15 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.25.9
+    version: 0.25.12
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 1.0.7
+    version: 1.0.8
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.19.8
+    version: 0.19.9
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -238,7 +238,7 @@ repositories:
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: 4.3.5
+    version: 4.3.6
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
@@ -274,15 +274,15 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 16.0.11
+    version: 16.0.12
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 3.3.15
+    version: 3.3.16
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 2.4.4
+    version: 2.4.5
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
@@ -298,7 +298,7 @@ repositories:
   ros2/rmw_connextdds:
     type: git
     url: https://github.com/ros2/rmw_connextdds.git
-    version: 0.11.3
+    version: 0.11.4
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
@@ -322,7 +322,7 @@ repositories:
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.18.11
+    version: 0.18.12
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -334,7 +334,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.15.13
+    version: 0.15.14
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -370,7 +370,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 11.2.14
+    version: 11.2.16
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -378,7 +378,7 @@ repositories:
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: 0.10.5
+    version: 0.10.6
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git


### PR DESCRIPTION
- [x] Waiting on releases to be merged in (see https://github.com/ros/rosdistro/pulls?q=is%3Aopen+is%3Apr+author%3Aaudrow+label%3Ahumble)
- [x] https://github.com/ros2/rosbag2/pull/1950 
- [x] https://github.com/ros/rosdistro/pull/44888

> ~~Note aarch64 jobs are failing due to something with the connext license. I don't think this should be occurring. I've asked in the OSRF Slack.~~

CI:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=22898)](http://ci.ros2.org/job/ci_linux/22898/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=17141)](http://ci.ros2.org/job/ci_linux-aarch64/17141/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=2389)](http://ci.ros2.org/job/ci_linux-rhel/2389/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=23776)](http://ci.ros2.org/job/ci_windows/23776/)

Build jobs:

https://ci.ros2.org/view/packaging/job/packaging_linux/3768/
https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/3117/
https://ci.ros2.org/view/packaging/job/packaging_linux-rhel/2266/
https://ci.ros2.org/view/packaging/job/packaging_windows/3567/