### PR TITLE
Added rosidl_rust repository

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -199,6 +199,10 @@ repositories:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
     version: master
+  ros2-rust/rosidl_rust:
+    type: git
+    url: https://github.com/ros2-rust/rosidl_rust.git
+    version: main
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git


### PR DESCRIPTION
This PR adds the rosidl_rust repository so that the Rust generator is available when building the ROS 2 repos from source.