### PR TITLE
Revert "Added rosidl_rust repository"

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -199,10 +199,6 @@ repositories:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
     version: master
-  ros2-rust/rosidl_rust:
-    type: git
-    url: https://github.com/ros2-rust/rosidl_rust.git
-    version: main
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git


### PR DESCRIPTION
Reverts ros2/ros2#1674

I thought this had been run through CI already, but apparently not (https://ci.ros2.org/job/ci_windows/24142/console)