### PR TITLE
added rosdistro dependency in pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -103,6 +103,7 @@ python-fastjsonschema = "==2.19.0"
 python-orocos-kdl = "==1.5.1"
 pyyaml = "==6.0.1"
 qt = "==5.15.8"  # TODO: Conda doesn't have 5.15.13
+rosdistro = "==0.9.0"
 rust = "==1.75.0"
 setuptools = "==68.1.2"
 six = "==1.16.0"


### PR DESCRIPTION
In fresh installation using binary method, an error is produced while using ```ros2 doctor -r```:

```
C:\pixi_ws>ros2 doctor
C:\pixi_ws\ros2-windows\Lib\site-packages\ros2doctor\api\network.py: 87: UserWarning: ERROR: No loopback IP address is found.
C:\pixi_ws\ros2-windows\Lib\site-packages\ros2doctor\api\network.py: 93: UserWarning: No multicast IP address is found.
C:\pixi_ws\ros2-windows\Lib\site-packages\ros2doctor\api\__init__.py: 107: UserWarning: Check entry point PackageCheck fails to load: No module named 'rosdistro'
C:\pixi_ws\ros2-windows\Lib\site-packages\ros2doctor\api\__init__.py: 107: UserWarning: Check entry point PlatformCheck fails to load: No module named 'rosdistro'
```

It misses to install ```rosdistro``` python module. When I installed ```rosdistro``` python module manually the ```ros2 doctor -r``` was working fine

```
C:\pixi_ws>ros2 doctor -r
C:\pixi_ws\ros2-windows\Lib\site-packages\ros2doctor\api\__init__.py: 162: UserWarning: Fail to call NetworkReport class functions.

   PACKAGE VERSIONS
actionlib_msgs                            : latest=5.5.0, local=5.5.0
action_msgs                               : latest=2.3.0, local=2.3.0
action_tutorials_cpp                      : latest=0.36.0, local=0.36.0
action_tutorials_py                       : latest=0.36.0, local=0.36.0
ament_clang_format                        : latest=0.19.2, local=0.19.2
ament_clang_tidy                          : latest=0.19.2, local=0.19.2
ament_cmake                               : latest=2.7.3, local=2.7.3
ament_cmake_auto                          : latest=2.7.3, local=2.7.3
ament_cmake_clang_format                  : latest=0.19.2, local=0.19.2
ament_cmake_clang_tidy                    : latest=0.19.2, local=0.19.2
ament_cmake_copyright                     : latest=0.19.2, local=0.19.2
ament_cmake_core                          : latest=2.7.3, local=2.7.3
ament_cmake_cppcheck                      : latest=0.19.2, local=0.19.2
ament_cmake_cpplint                       : latest=0.19.2, local=0.19.2
ament_cmake_export_definitions            : latest=2.7.3, local=2.7.3
ament_cmake_export_dependencies           : latest=2.7.3, local=2.7.3
ament_cmake_export_include_directories    : latest=2.7.3, local=2.7.3
ament_cmake_export_interfaces             : latest=2.7.3, local=2.7.3
ament_cmake_export_libraries              : latest=2.7.3, local=2.7.3
ament_cmake_export_link_flags             : latest=2.7.3, local=2.7.3
ament_cmake_export_targets                : latest=2.7.3, local=2.7.3
ament_cmake_flake8                        : latest=0.19.2, local=0.19.2
ament_cmake_gen_version_h                 : latest=2.7.3, local=2.7.3
ament_cmake_gmock                         : latest=2.7.3, local=2.7.3
ament_cmake_google_benchmark              : latest=2.7.3, local=2.7.3
ament_cmake_gtest                         : latest=2.7.3, local=2.7.3
ament_cmake_include_directories           : latest=2.7.3, local=2.7.3
ament_cmake_libraries                     : latest=2.7.3, local=2.7.3
ament_cmake_lint_cmake                    : latest=0.19.2, local=0.19.2
ament_cmake_mypy                          : latest=0.19.2, local=0.19.2
ament_cmake_pclint                        : latest=0.19.2, local=0.19.2
ament_cmake_pep257                        : latest=0.19.2, local=0.19.2
ament_cmake_pycodestyle                   : latest=0.19.2, local=0.19.2
ament_cmake_pyflakes                      : latest=0.19.2, local=0.19.2
ament_cmake_pytest                        : latest=2.7.3, local=2.7.3
ament_cmake_python                        : latest=2.7.3, local=2.7.3
ament_cmake_ros                           : latest=0.14.3, local=0.14.3
ament_cmake_ros_core                      : latest=0.14.3, local=0.14.3
ament_cmake_target_dependencies           : latest=2.7.3, local=2.7.3
ament_cmake_test                          : latest=2.7.3, local=2.7.3
ament_cmake_uncrustify                    : latest=0.19.2, local=0.19.2
ament_cmake_vendor_package                : latest=2.7.3, local=2.7.3
ament_cmake_version                       : latest=2.7.3, local=2.7.3
ament_cmake_xmllint                       : latest=0.19.2, local=0.19.2
ament_copyright                           : latest=0.19.2, local=0.19.2
ament_cppcheck                            : latest=0.19.2, local=0.19.2
ament_cpplint                             : latest=0.19.2, local=0.19.2
ament_flake8                              : latest=0.19.2, local=0.19.2
ament_index_cpp                           : latest=1.11.0, local=1.11.0
ament_index_python                        : latest=1.11.0, local=1.11.0
ament_lint                                : latest=0.19.2, local=0.19.2
ament_lint_auto                           : latest=0.19.2, local=0.19.2
ament_lint_cmake                          : latest=0.19.2, local=0.19.2
ament_lint_common                         : latest=0.19.2, local=0.19.2
ament_mypy                                : latest=0.19.2, local=0.19.2
ament_package                             : latest=0.17.2, local=0.17.2
ament_pclint                              : latest=0.19.2, local=0.19.2
ament_pep257                              : latest=0.19.2, local=0.19.2
ament_pycodestyle                         : latest=0.19.2, local=0.19.2
ament_pyflakes                            : latest=0.19.2, local=0.19.2
ament_uncrustify                          : latest=0.19.2, local=0.19.2
ament_xmllint                             : latest=0.19.2, local=0.19.2
builtin_interfaces                        : latest=2.3.0, local=2.3.0
camera_calibration_parsers                : latest=6.1.1, local=6.1.1
camera_info_manager                       : latest=6.1.1, local=6.1.1
camera_info_manager_py                    : latest=6.1.1, local=6.1.1
class_loader                              : latest=2.8.0, local=2.8.0
common_interfaces                         : latest=5.5.0, local=5.5.0
composition                               : latest=0.36.0, local=0.36.0
composition_interfaces                    : latest=2.3.0, local=2.3.0
console_bridge_vendor                     : latest=1.8.0, local=1.8.0
demo_nodes_cpp                            : latest=0.36.0, local=0.36.0
demo_nodes_cpp_native                     : latest=0.36.0, local=0.36.0
demo_nodes_py                             : latest=0.36.0, local=0.36.0
diagnostic_msgs                           : latest=5.5.0, local=5.5.0
domain_coordinator                        : latest=0.14.3, local=0.14.3
dummy_map_server                          : latest=0.36.0, local=0.36.0
dummy_robot_bringup                       : latest=0.36.0, local=0.36.0
dummy_sensors                             : latest=0.36.0, local=0.36.0
eigen3_cmake_module                       : latest=0.4.0, local=0.4.0
examples_rclcpp_async_client              : latest=0.20.5, local=0.20.5
examples_rclcpp_cbg_executor              : latest=0.20.5, local=0.20.5
examples_rclcpp_minimal_action_client     : latest=0.20.5, local=0.20.5
examples_rclcpp_minimal_action_server     : latest=0.20.5, local=0.20.5
examples_rclcpp_minimal_client            : latest=0.20.5, local=0.20.5
examples_rclcpp_minimal_composition       : latest=0.20.5, local=0.20.5
examples_rclcpp_minimal_publisher         : latest=0.20.5, local=0.20.5
examples_rclcpp_minimal_service           : latest=0.20.5, local=0.20.5
examples_rclcpp_minimal_subscriber        : latest=0.20.5, local=0.20.5
examples_rclcpp_minimal_timer             : latest=0.20.5, local=0.20.5
examples_rclcpp_multithreaded_executor    : latest=0.20.5, local=0.20.5
examples_rclcpp_wait_set                  : latest=0.20.5, local=0.20.5
examples_rclpy_executors                  : latest=0.20.5, local=0.20.5
examples_rclpy_guard_conditions           : latest=0.20.5, local=0.20.5
examples_rclpy_minimal_action_client      : latest=0.20.5, local=0.20.5
examples_rclpy_minimal_action_server      : latest=0.20.5, local=0.20.5
examples_rclpy_minimal_client             : latest=0.20.5, local=0.20.5
examples_rclpy_minimal_publisher          : latest=0.20.5, local=0.20.5
examples_rclpy_minimal_service            : latest=0.20.5, local=0.20.5
examples_rclpy_minimal_subscriber         : latest=0.20.5, local=0.20.5
examples_rclpy_pointcloud_publisher       : latest=0.20.5, local=0.20.5
examples_tf2_py                           : latest=0.41.0, local=0.41.0
example_interfaces                        : latest=0.13.0, local=0.13.0
geometry2                                 : latest=0.41.0, local=0.41.0
geometry_msgs                             : latest=5.5.0, local=5.5.0
gz_cmake_vendor                           : latest=0.2.2, local=0.2.2
gz_math_vendor                            : latest=0.2.3, local=0.2.3
gz_utils_vendor                           : latest=0.2.2, local=0.2.2
image_common                              : latest=6.1.1, local=6.1.1
image_tools                               : latest=0.36.0, local=0.36.0
image_transport                           : latest=6.1.1, local=6.1.1
image_transport_py                        : latest=6.1.1, local=6.1.1
interactive_markers                       : latest=2.7.0, local=2.7.0
intra_process_demo                        : latest=0.36.0, local=0.36.0
kdl_parser                                : latest=2.12.1, local=2.12.1
keyboard_handler                          : latest=0.4.0, local=0.4.0
laser_geometry                            : latest=2.10.0, local=2.10.0
launch                                    : latest=3.8.1, local=3.8.1
launch_pytest                             : latest=3.8.1, local=3.8.1
launch_ros                                : latest=0.28.1, local=0.28.1
launch_testing                            : latest=3.8.1, local=3.8.1
launch_testing_ament_cmake                : latest=3.8.1, local=3.8.1
launch_testing_examples                   : latest=0.20.5, local=0.20.5
launch_testing_ros                        : latest=0.28.1, local=0.28.1
launch_xml                                : latest=3.8.1, local=3.8.1
launch_yaml                               : latest=3.8.1, local=3.8.1
libcurl_vendor                            : latest=3.7.0, local=3.7.0
liblz4_vendor                             : latest=0.32.0, local=0.32.0
libstatistics_collector                   : latest=2.0.1, local=2.0.1
libyaml_vendor                            : latest=1.7.1, local=1.7.1
lifecycle                                 : latest=0.36.0, local=0.36.0
lifecycle_msgs                            : latest=2.3.0, local=2.3.0
lifecycle_py                              : latest=0.36.0, local=0.36.0
logging_demo                              : latest=0.36.0, local=0.36.0
lttngpy                                   : latest=8.6.0, local=8.6.0
map_msgs                                  : latest=2.5.0, local=2.5.0
mcap_vendor                               : latest=0.32.0, local=0.32.0
message_filters                           : latest=7.1.0, local=7.1.0
mimick_vendor                             : latest=0.8.1, local=0.8.1
nav_msgs                                  : latest=5.5.0, local=5.5.0
orocos_kdl_vendor                         : latest=0.7.1, local=0.7.1
osrf_pycommon                             : latest=2.1.4, local=2.1.6
pendulum_msgs                             : latest=0.36.0, local=0.36.0
performance_test_fixture                  : latest=0.3.1, local=0.3.1
pluginlib                                 : latest=5.6.0, local=5.6.0
point_cloud_transport                     : latest=5.1.1, local=5.1.2
point_cloud_transport_py                  : latest=5.1.1, local=5.1.2
pybind11_vendor                           : latest=3.2.0, local=3.2.0
python_orocos_kdl_vendor                  : latest=0.7.1, local=0.7.1
python_qt_binding                         : latest=2.3.1, local=2.3.1
qt_dotgraph                               : latest=2.9.1, local=2.9.1
qt_gui                                    : latest=2.9.1, local=2.9.1
qt_gui_app                                : latest=2.9.1, local=2.9.1
qt_gui_core                               : latest=2.9.1, local=2.9.1
qt_gui_cpp                                : latest=2.9.1, local=2.9.1
qt_gui_py_common                          : latest=2.9.1, local=2.9.1
quality_of_service_demo_cpp               : latest=0.36.0, local=0.36.0
quality_of_service_demo_py                : latest=0.36.0, local=0.36.0
rcl                                       : latest=10.1.0, local=10.1.0
rclcpp                                    : latest=29.5.0, local=29.5.0
rclcpp_action                             : latest=29.5.0, local=29.5.0
rclcpp_components                         : latest=29.5.0, local=29.5.0
rclcpp_lifecycle                          : latest=29.5.0, local=29.5.0
rclpy                                     : latest=9.1.0, local=9.1.0
rcl_action                                : latest=10.1.0, local=10.1.0
rcl_interfaces                            : latest=2.3.0, local=2.3.0
rcl_lifecycle                             : latest=10.1.0, local=10.1.0
rcl_logging_interface                     : latest=3.2.2, local=3.2.2
rcl_logging_noop                          : latest=3.2.2, local=3.2.2
rcl_logging_spdlog                        : latest=3.2.2, local=3.2.2
rcl_yaml_param_parser                     : latest=10.1.0, local=10.1.0
rcpputils                                 : latest=2.13.4, local=2.13.4
rcutils                                   : latest=6.9.5, local=6.9.5
resource_retriever                        : latest=3.7.0, local=3.7.0
rmw                                       : latest=7.8.2, local=7.8.2
rmw_connextdds                            : latest=1.1.0, local=1.1.0
rmw_connextddsmicro                       : latest=N/A, local=1.1.0
rmw_connextdds_common                     : latest=1.1.0, local=1.1.0
rmw_cyclonedds_cpp                        : latest=4.0.2, local=4.0.2
rmw_dds_common                            : latest=3.2.1, local=3.2.1
rmw_fastrtps_cpp                          : latest=9.3.2, local=9.3.2
rmw_fastrtps_dynamic_cpp                  : latest=9.3.2, local=9.3.2
rmw_fastrtps_shared_cpp                   : latest=9.3.2, local=9.3.2
rmw_implementation                        : latest=3.0.4, local=3.0.4
rmw_implementation_cmake                  : latest=7.8.2, local=7.8.2
rmw_security_common                       : latest=7.8.2, local=7.8.2
rmw_test_fixture                          : latest=0.14.3, local=0.14.3
rmw_test_fixture_implementation           : latest=0.14.3, local=0.14.3
rmw_zenoh_cpp                             : latest=0.6.0, local=0.6.0
robot_state_publisher                     : latest=3.4.2, local=3.4.2
ros2action                                : latest=0.38.0, local=0.38.0
ros2bag                                   : latest=0.32.0, local=0.32.0
ros2cli                                   : latest=0.38.0, local=0.38.0
ros2cli_common_extensions                 : latest=0.4.0, local=0.4.0
ros2cli_test_interfaces                   : latest=0.38.0, local=0.38.0
ros2component                             : latest=0.38.0, local=0.38.0
ros2doctor                                : latest=0.38.0, local=0.38.0
ros2interface                             : latest=0.38.0, local=0.38.0
ros2launch                                : latest=0.28.1, local=0.28.1
ros2lifecycle                             : latest=0.38.0, local=0.38.0
ros2lifecycle_test_fixtures               : latest=0.38.0, local=0.38.0
ros2multicast                             : latest=0.38.0, local=0.38.0
ros2node                                  : latest=0.38.0, local=0.38.0
ros2param                                 : latest=0.38.0, local=0.38.0
ros2pkg                                   : latest=0.38.0, local=0.38.0
ros2run                                   : latest=0.38.0, local=0.38.0
ros2service                               : latest=0.38.0, local=0.38.0
ros2test                                  : latest=0.8.0, local=0.8.0
ros2topic                                 : latest=0.38.0, local=0.38.0
ros2trace                                 : latest=8.6.0, local=8.6.0
rosbag2                                   : latest=0.32.0, local=0.32.0
rosbag2_compression                       : latest=0.32.0, local=0.32.0
rosbag2_compression_zstd                  : latest=0.32.0, local=0.32.0
rosbag2_cpp                               : latest=0.32.0, local=0.32.0
rosbag2_examples_cpp                      : latest=0.32.0, local=0.32.0
rosbag2_examples_py                       : latest=0.32.0, local=0.32.0
rosbag2_interfaces                        : latest=0.32.0, local=0.32.0
rosbag2_py                                : latest=0.32.0, local=0.32.0
rosbag2_storage                           : latest=0.32.0, local=0.32.0
rosbag2_storage_default_plugins           : latest=0.32.0, local=0.32.0
rosbag2_storage_mcap                      : latest=0.32.0, local=0.32.0
rosbag2_storage_sqlite3                   : latest=0.32.0, local=0.32.0
rosbag2_tests                             : latest=0.32.0, local=0.32.0
rosbag2_test_common                       : latest=0.32.0, local=0.32.0
rosbag2_test_msgdefs                      : latest=0.32.0, local=0.32.0
rosbag2_transport                         : latest=0.32.0, local=0.32.0
rosgraph_msgs                             : latest=2.3.0, local=2.3.0
rosidl_adapter                            : latest=4.9.4, local=4.9.4
rosidl_cli                                : latest=4.9.4, local=4.9.4
rosidl_cmake                              : latest=4.9.4, local=4.9.4
rosidl_core_generators                    : latest=0.3.1, local=0.3.1
rosidl_core_runtime                       : latest=0.3.1, local=0.3.1
rosidl_default_generators                 : latest=1.7.1, local=1.7.1
rosidl_default_runtime                    : latest=1.7.1, local=1.7.1
rosidl_dynamic_typesupport                : latest=0.3.1, local=0.3.1
rosidl_dynamic_typesupport_fastrtps       : latest=0.4.1, local=0.4.1
rosidl_generator_c                        : latest=4.9.4, local=4.9.4
rosidl_generator_cpp                      : latest=4.9.4, local=4.9.4
rosidl_generator_dds_idl                  : latest=0.12.1, local=0.12.1
rosidl_generator_py                       : latest=0.24.1, local=0.24.1
rosidl_generator_tests                    : latest=N/A, local=4.9.4
rosidl_generator_type_description         : latest=4.9.4, local=4.9.4
rosidl_parser                             : latest=4.9.4, local=4.9.4
rosidl_pycommon                           : latest=4.9.4, local=4.9.4
rosidl_runtime_c                          : latest=4.9.4, local=4.9.4
rosidl_runtime_cpp                        : latest=4.9.4, local=4.9.4
rosidl_runtime_py                         : latest=0.14.1, local=0.14.1
rosidl_typesupport_c                      : latest=3.3.3, local=3.3.3
rosidl_typesupport_cpp                    : latest=3.3.3, local=3.3.3
rosidl_typesupport_fastrtps_c             : latest=3.8.0, local=3.8.0
rosidl_typesupport_fastrtps_cpp           : latest=3.8.0, local=3.8.0
rosidl_typesupport_interface              : latest=4.9.4, local=4.9.4
rosidl_typesupport_introspection_c        : latest=4.9.4, local=4.9.4
rosidl_typesupport_introspection_cpp      : latest=4.9.4, local=4.9.4
rosidl_typesupport_introspection_tests    : latest=N/A, local=4.9.4
rosidl_typesupport_tests                  : latest=N/A, local=3.3.3
ros_environment                           : latest=4.3.1, local=4.3.1
ros_testing                               : latest=0.8.0, local=0.8.0
rpyutils                                  : latest=0.6.2, local=0.6.2
rqt                                       : latest=1.9.0, local=1.9.0
rqt_action                                : latest=2.3.0, local=2.3.0
rqt_bag                                   : latest=2.0.2, local=2.0.2
rqt_bag_plugins                           : latest=2.0.2, local=2.0.2
rqt_console                               : latest=2.3.1, local=2.3.1
rqt_graph                                 : latest=1.7.0, local=1.7.0
rqt_gui                                   : latest=1.9.0, local=1.9.0
rqt_gui_cpp                               : latest=1.9.0, local=1.9.0
rqt_gui_py                                : latest=1.9.0, local=1.9.0
rqt_msg                                   : latest=1.6.0, local=1.6.0
rqt_plot                                  : latest=1.6.2, local=1.6.2
rqt_publisher                             : latest=1.9.0, local=1.9.0
rqt_py_common                             : latest=1.9.0, local=1.9.0
rqt_py_console                            : latest=1.4.0, local=1.4.0
rqt_reconfigure                           : latest=1.7.0, local=1.7.0
rqt_service_caller                        : latest=1.4.0, local=1.4.0
rqt_shell                                 : latest=1.3.1, local=1.3.1
rqt_srv                                   : latest=1.3.0, local=1.3.0
rqt_topic                                 : latest=1.8.0, local=1.8.1
rti_connext_dds_cmake_module              : latest=1.1.0, local=1.1.0
rviz2                                     : latest=15.0.0, local=15.0.0
rviz_assimp_vendor                        : latest=15.0.0, local=15.0.0
rviz_common                               : latest=15.0.0, local=15.0.0
rviz_default_plugins                      : latest=15.0.0, local=15.0.0
rviz_ogre_vendor                          : latest=15.0.0, local=15.0.0
rviz_rendering                            : latest=15.0.0, local=15.0.0
rviz_rendering_tests                      : latest=15.0.0, local=15.0.0
rviz_resource_interfaces                  : latest=15.0.0, local=15.0.0
rviz_visual_testing_framework             : latest=15.0.0, local=15.0.0
sensor_msgs                               : latest=5.5.0, local=5.5.0
sensor_msgs_py                            : latest=5.5.0, local=5.5.0
service_msgs                              : latest=2.3.0, local=2.3.0
shape_msgs                                : latest=5.5.0, local=5.5.0
spdlog_vendor                             : latest=1.7.0, local=1.7.0
sqlite3_vendor                            : latest=0.32.0, local=0.32.0
sros2                                     : latest=0.15.2, local=0.15.2
sros2_cmake                               : latest=0.15.2, local=0.15.2
statistics_msgs                           : latest=2.3.0, local=2.3.0
std_msgs                                  : latest=5.5.0, local=5.5.0
std_srvs                                  : latest=5.5.0, local=5.5.0
stereo_msgs                               : latest=5.5.0, local=5.5.0
tango_icons_vendor                        : latest=0.4.0, local=0.4.0
test_cli                                  : latest=N/A, local=0.24.0
test_cli_remapping                        : latest=N/A, local=0.24.0
test_communication                        : latest=N/A, local=0.24.0
test_interface_files                      : latest=0.13.0, local=0.13.0
test_launch_ros                           : latest=N/A, local=0.28.1
test_launch_testing                       : latest=N/A, local=3.8.1
test_msgs                                 : latest=2.3.0, local=2.3.0
test_quality_of_service                   : latest=N/A, local=0.24.0
test_rclcpp                               : latest=N/A, local=0.24.0
test_rmw_implementation                   : latest=N/A, local=3.0.4
test_ros2trace                            : latest=N/A, local=8.6.0
test_security                             : latest=N/A, local=0.24.0
test_tf2                                  : latest=N/A, local=0.41.0
test_tracetools                           : latest=N/A, local=8.6.0
test_tracetools_launch                    : latest=N/A, local=8.6.0
tf2                                       : latest=0.41.0, local=0.41.0
tf2_bullet                                : latest=0.41.0, local=0.41.0
tf2_eigen                                 : latest=0.41.0, local=0.41.0
tf2_eigen_kdl                             : latest=0.41.0, local=0.41.0
tf2_geometry_msgs                         : latest=0.41.0, local=0.41.0
tf2_kdl                                   : latest=0.41.0, local=0.41.0
tf2_msgs                                  : latest=0.41.0, local=0.41.0
tf2_py                                    : latest=0.41.0, local=0.41.0
tf2_ros                                   : latest=0.41.0, local=0.41.0
tf2_ros_py                                : latest=0.41.0, local=0.41.0
tf2_sensor_msgs                           : latest=0.41.0, local=0.41.0
tf2_tools                                 : latest=0.41.0, local=0.41.0
tinyxml2_vendor                           : latest=0.10.0, local=0.10.0
topic_monitor                             : latest=0.36.0, local=0.36.0
topic_statistics_demo                     : latest=0.36.0, local=0.36.0
tracetools                                : latest=8.6.0, local=8.6.0
tracetools_launch                         : latest=8.6.0, local=8.6.0
tracetools_read                           : latest=8.6.0, local=8.6.0
tracetools_test                           : latest=8.6.0, local=8.6.0
tracetools_trace                          : latest=8.6.0, local=8.6.0
trajectory_msgs                           : latest=5.5.0, local=5.5.0
turtlesim                                 : latest=1.9.2, local=1.9.2
turtlesim_msgs                            : latest=1.9.2, local=1.9.2
type_description_interfaces               : latest=2.3.0, local=2.3.0
uncrustify_vendor                         : latest=3.1.0, local=3.1.0
unique_identifier_msgs                    : latest=2.7.0, local=2.7.0
urdf                                      : latest=2.12.2, local=2.12.2
urdf_parser_plugin                        : latest=2.12.2, local=2.12.2
visualization_msgs                        : latest=5.5.0, local=5.5.0
yaml_cpp_vendor                           : latest=9.1.0, local=9.1.0
zenoh_cpp_vendor                          : latest=0.6.0, local=0.6.0
zenoh_security_tools                      : latest=0.6.0, local=0.6.0
zstd_vendor                               : latest=0.32.0, local=0.32.0

   PLATFORM INFORMATION
system           : Windows
platform info    : Windows-10-10.0.19045-SP0
release          : 10
processor        : Intel64 Family 6 Model 186 Stepping 3, GenuineIntel

   QOS COMPATIBILITY LIST
compatibility status    : No publisher/subscriber pairs found

   RMW MIDDLEWARE
middleware name    : rmw_fastrtps_cpp

   ROS 2 INFORMATION
distribution name      : kilted
distribution type      : ros2
distribution status    : pre-release
release platforms      : {'debian': ['bookworm'], 'rhel': ['9'], 'ubuntu': ['noble']}

   TOPIC LIST
topic               : none
publisher count     : 0
subscriber count    : 0
```