### PR TITLE
Change pixi shell name to pixi_ros2_kilted

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pixi_ros2_rolling"
+name = "pixi_ros2_kilted"
 version = "0.1.0"
 description = "Dependencies to build ROS 2 on Windows"
 authors = ["Chris Lalancette <clalancette@gmail.com>"]


### PR DESCRIPTION
Fixes pixi shell name being wrong when building kilted
Referenced by @Matt5sean3 in [#297](https://github.com/ros2/kilted_tutorial_party/issues/297#issuecomment-2846221396)