### PR TITLE
Add in a pixi dependency for rosdistro.

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -118,3 +118,6 @@ yamllint = "==1.33.0"
 yaml = "==0.2.5"
 zipp = "==1.0.0"
 zstd = "==1.5.5"
+
+[pypi-dependencies]
+rosdistro = "==1.0.0"

--- a/pixi.toml
+++ b/pixi.toml
@@ -103,6 +103,7 @@ python-fastjsonschema = "==2.19.0"
 python-orocos-kdl = "==1.5.1"
 pyyaml = "==6.0.1"
 qt = "==5.15.8"  # TODO: Conda doesn't have 5.15.13
+rosdistro = "==1.0.0"
 rust = "==1.75.0"
 setuptools = "==68.1.2"
 six = "==1.16.0"
@@ -118,6 +119,3 @@ yamllint = "==1.33.0"
 yaml = "==0.2.5"
 zipp = "==1.0.0"
 zstd = "==1.5.5"
-
-[pypi-dependencies]
-rosdistro = "==1.0.0"


### PR DESCRIPTION
This is required for ros2 doctor to operate properly. We didn't notice this before because we skip ros2doctor tests on Windows because of unrelated issues, but testing during the Kilted tutorial party showed it.

This fix should be backported to Kilted, Jazzy, and Humble.

This came out of https://github.com/ros2/kilted_tutorial_party/issues/38

@cottsay FYI for Kilted.