### PR TITLE
update branch urdfdom headers on kilted

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -198,7 +198,7 @@ repositories:
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
-    version: master
+    version: kilted
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git


### PR DESCRIPTION
Related with this change https://github.com/ros/urdfdom_headers/pull/86

Build are broken until this fix is in