### PR TITLE
Humble release versions 2025-07-18

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -10,7 +10,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.12.12
+    version: 0.12.13
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -218,15 +218,15 @@ repositories:
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: 0.15.3
+    version: 0.15.4
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.25.12
+    version: 0.25.15
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 1.0.8
+    version: 1.0.10
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
@@ -238,7 +238,7 @@ repositories:
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: 4.3.6
+    version: 4.3.8
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
@@ -262,11 +262,11 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 5.3.9
+    version: 5.3.10
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: 1.2.1
+    version: 1.2.2
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
@@ -274,11 +274,11 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 16.0.12
+    version: 16.0.14
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 3.3.16
+    version: 3.3.17
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
@@ -310,11 +310,11 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 6.2.7
+    version: 6.2.8
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 2.8.4
+    version: 2.8.5
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
@@ -322,7 +322,7 @@ repositories:
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.18.12
+    version: 0.18.13
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -334,11 +334,11 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.15.14
+    version: 0.15.15
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 3.1.6
+    version: 3.1.7
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
@@ -350,7 +350,7 @@ repositories:
   ros2/rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: 0.14.4
+    version: 0.14.5
   ros2/rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
@@ -370,7 +370,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 11.2.16
+    version: 11.2.19
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -378,7 +378,7 @@ repositories:
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: 0.10.6
+    version: 0.10.7
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 1.3.11
+    version: 1.3.12
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -14,7 +14,7 @@ repositories:
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.14.0
+    version: 0.14.1
   ament/google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
@@ -34,7 +34,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.6.9
+    version: v2.6.10
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -47,18 +47,18 @@ repositories:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
     version: v2.0.5
-  ignition/ignition_cmake2_vendor:
+  gazebo-release/gz_cmake2_vendor:
     type: git
-    url: https://github.com/ignition-release/ignition_cmake2_vendor.git
+    url: https://github.com/gazebo-release/gz_cmake2_vendor.git
     version: 0.0.2
-  ignition/ignition_math6_vendor:
+  gazebo-release/gz_math6_vendor:
     type: git
-    url: https://github.com/ignition-release/ignition_math6_vendor.git
+    url: https://github.com/gazebo-release/gz_math6_vendor.git
     version: 0.0.2
   osrf/osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: 2.1.4
+    version: 2.1.6
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
@@ -66,7 +66,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: 3.1.11
+    version: 3.1.12
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -122,7 +122,7 @@ repositories:
   ros-visualization/rqt_plot:
     type: git
     url: https://github.com/ros-visualization/rqt_plot.git
-    version: 1.1.4
+    version: 1.1.5
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
@@ -198,7 +198,7 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 4.8.0
+    version: 4.9.0
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
@@ -230,7 +230,7 @@ repositories:
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.19.9
+    version: 0.19.10
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git


### PR DESCRIPTION
Announcement: https://discourse.ros.org/t/preparing-for-humble-sync-and-patch-release-2025-07-18/45250

This is my first patch release. Some notes:

* I skipped ros2/demos and ros2/performance_test_fixture, since they only have simple changes to their READMEs or local GitHub CI configs
* I updated eProsima/Fast-DDS to v2.6.10 since it was bumped by eProsima
* eclipse-cyclonedds/cyclonedds and eclipse-iceoryx/iceoryx have some recent commits, but no new rosdistro release, so I left them as-is
* I left eProsima/foonathan_memory_vendor as-is:
    * ros2.repos @ humble points to foonathan_memory_vendor @ master
    * ros2.repos @ humble-release points to foonathan_memory_vendor @ v1.2.0
    * but foonathan_memory_vendor @ master has many more recent versions (v1.3.1)
    * however, rosdistro still has version 1.2.0, so I left it as-is
* I updated osrf/osrf_pycommon:
    * ROS Boss guide says "Humble notes: Probably don't update osrf/osrf_pycommon"
    * even if ros2.repos @ humble-release still points to 2.1.4
    * but 2.1.6 was released into Humble rosdistro by Audrow before the last Humble patch: https://github.com/ros/rosdistro/pull/44866, so I updated it for consistency with the apt repo

CI:

* TODO

Packaging:

* TODO