### PR TITLE
Removed pybind11 vendor package

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -70,7 +70,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: ahcorde/rolling/pybind11_vendor
+    version: rolling
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -78,7 +78,7 @@ repositories:
   ros-perception/point_cloud_transport:
     type: git
     url: https://github.com/ros-perception/point_cloud_transport.git
-    version: ahcorde/rolling/pybind11_vendor
+    version: rolling
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
@@ -258,7 +258,7 @@ repositories:
   ros2/orocos_kdl_vendor:
     type: git
     url: https://github.com/ros2/orocos_kdl_vendor.git
-    version: ahcorde/rolling/pybind11_vendor
+    version: rolling
   ros2/performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
@@ -282,7 +282,7 @@ repositories:
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: ahcorde/rolling/pybind11_vendor
+    version: rolling
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
@@ -326,7 +326,7 @@ repositories:
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: ahcorde/rolling/pybind11_vendor
+    version: rolling
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
@@ -342,7 +342,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: ahcorde/rolling/pybind11_vendor
+    version: rolling
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git


### PR DESCRIPTION
Related with this metaticket https://github.com/ros2/ros2/issues/1729

 - pybind11
    - Ubuntu noble provides 2.11.1 
    - Windows pixi provides 2.11.1
    - RHEL 2.10.4

modfied packages (branch ahcorde/rolling/pybind11_vendor):
 - image_transport_py https://github.com/ros-perception/image_common/pull/374
 - point_cloud_transport_py https://github.com/ros-perception/point_cloud_transport/pull/131
 - python_orocos_kdl_vendor https://github.com/ros2/orocos_kdl_vendor/pull/38
 - rclpy https://github.com/ros2/rclpy/pull/1497
 - lttngpy https://github.com/ros2/ros2_tracing/pull/197
 - rosbag2_py https://github.com/ros2/rosbag2/pull/2154

## Build

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=24721)](http://ci.ros2.org/job/ci_linux/24721/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=18750)](http://ci.ros2.org/job/ci_linux-aarch64/18750/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=4170)](http://ci.ros2.org/job/ci_linux-rhel/4170/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=25237)](http://ci.ros2.org/job/ci_windows/25237/)