### PR TITLE
Removed uncrustify vendor

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -23,10 +23,6 @@ repositories:
     type: git
     url: https://github.com/ament/googletest.git
     version: rolling
-  ament/uncrustify_vendor:
-    type: git
-    url: https://github.com/ament/uncrustify_vendor.git
-    version: rolling
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git


### PR DESCRIPTION
 - uncrustify
   - Ubuntu noble provides 0.78.1
   - Windows pixi provides 0.78.1
   - RHEL 0.75.1

packages:
 - ament_uncrustify
