### PR TITLE
Removed yaml_cpp_vendor

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -70,7 +70,7 @@ repositories:
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: rolling
+    version: ahcorde/rolling/removed_yamlcpp_vendor
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -346,7 +346,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: rolling
+    version: ahcorde/rolling/removed_yamlcpp_vendor
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -394,7 +394,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: rolling
+    version: ahcorde/rolling/removed_yamlcpp_vendor
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -426,8 +426,4 @@ repositories:
   ros2/urdf:
     type: git
     url: https://github.com/ros2/urdf.git
-    version: rolling
-  ros2/yaml_cpp_vendor:
-    type: git
-    url: https://github.com/ros2/yaml_cpp_vendor.git
     version: rolling


### PR DESCRIPTION
Related with https://github.com/ros2/ros2/issues/1729

 - yaml-cpp
    - Ubuntu noble provides 0.8
    - Windows pixi provides 0.8
    - RHEL 0.6.3

Related packages:
 - rviz2
 - rosbag2
 - image_common