### PR TITLE
Install cli11 for gz_utils_vendor

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -40,6 +40,7 @@ assimp = "==5.3.1"
 benchmark = "==1.8.3"
 bullet = "==3.25"  # TODO: Conda has 3.24, but it is not installable with Python 3.12
 catkin_pkg = "==1.0.0"
+cli11 = "==2.4.1"
 cmake = "==3.28.3"
 console_bridge = "==1.0.1"
 coverage = "==7.4.4"


### PR DESCRIPTION
Adds `cli11` which is needed by `gz_utils_vendor` in Gazebo Jetty.  See https://github.com/ros2/ci/pull/825

Related to:
https://github.com/gazebo-release/gz_utils_vendor/pull/11