### PR TITLE
Add types-pyyaml to pixi

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -112,6 +112,7 @@ snowballstemmer = "==2.2.0"
 spdlog = "==1.12.0"
 sqlite = "==3.45.2"  # TODO: Conda has 3.45.1, but it is not installable with Python 3.12
 tinyxml2 = "==10.0.0"
+types-pyyaml = "==6.0.1"
 typing_extensions = "==4.10.0"
 uncrustify = "==0.78.1"
 vcstool = "==0.3.0"


### PR DESCRIPTION
## Description

Adds `types-pyyaml` to the pixi configuration. Already added to linux CI https://github.com/ros2/ci/pull/781.

Should unblock https://github.com/ros2/launch/pull/781.

### Is this user-facing behavior change?

Lets user see type hints for the pyyaml packages and test their projects with mypy.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
