### PR TITLE
Fix: Update `[project]` to `[workspace]` to resolve deprecation warning

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "pixi_ros2_rolling"
 version = "0.1.0"
 description = "Dependencies to build ROS 2 on Windows"


### PR DESCRIPTION


## Description

This pull request updates the pixi.toml file to use the current standard for defining the project scope, replacing the deprecated `[project]` table with `[workspace]`.

```bash
PS C:\Users\amjad\Documents\pixi_ws> pixi install
 WARN Encountered 1 warning while parsing the manifest:
  ⚠ The `project` field is deprecated. Use `workspace` instead.
   ╭─[C:\Users\amjad\Documents\pixi_ws\pixi.toml:1:1]
 1 │ ╭─▶ [project]
 2 │ │   name = "pixi_ros2_jazzy"
 3 │ │   version = "0.1.0"
 4 │ │   description = "Dependencies to build ROS 2 on Windows"
 5 │ │   authors = ["Chris Lalancette <clalancette@gmail.com>"]
 6 │ │   channels = ["conda-forge"]
 7 │ ├─▶ platforms = ["win-64"]
   · ╰──── replace this with 'workspace'
 8 │
   ╰────

✔ The default environment has been installed.
```

The change aligns the configuration with **the latest Pixi documentation**.