### PR TITLE
Discord to zulip link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once you've installed ROS start by learning some [basic concepts](https://docs.r
 ## Community Resources
 
 * [ROS Discussion Forum](https://discourse.ros.org/)
-* [ROS Discord Server](https://discord.com/servers/open-robotics-1077825543698927656)
+* [ROS Zulip Server](https://openrobotics.zulipchat.com/)
 * [Robotics Stack Exchange](https://robotics.stackexchange.com/) (preferred ROS support forum).
 * [Official ROS Videos](https://vimeo.com/osrfoundation)
 * [ROSCon](https://roscon.ros.org), our yearly developer conference. 


### PR DESCRIPTION
Changing discord link to the Zulip server link one which is now the standard place for chat support and collaboration.