### PR TITLE
Add github actions to upload nightlies binary archives from ros2ci

### DIFF
--- a/.github/workflows/release-nightlies.yaml
+++ b/.github/workflows/release-nightlies.yaml
@@ -57,7 +57,8 @@ jobs:
               break
             fi
           done <<< "$ARTIFACTS"  
-
+        env:
+          GH_TOKEN: ${{ github.token }}
       # Verify that all nightlies have passed and have been built in the last 24 hours
       - name: Verify conditions for update of artifacts
         id: verification


### PR DESCRIPTION
## Description

Fixes https://github.com/ros2/ci/issues/830

Adds a new GH Action that pulls the binary archives from ci.ros2.org and publish them on GH releases to an evergreen Nightlies release. 
The conditions for an update are:
- All jobs have to not have failed on their last nightly run. 
- All jobs have run in the last T-24 hours of the GH action run. 

The action is setup to run on schedule between 4AM-12PM UTC daily to accomodate the varying times the nightlies can last. If the complete set of nightlies have not finished then no action is taken, waiting for the next hour GH action run.

If the assets were updated by a previous run, then no action is taken as well. 

Since there is no source code to point to but GH releases are built on top of tags that need a specific commit to point to an orphaned branch was created to avoid confusion: https://github.com/ros2/ros2/tree/ros2ci-nightlies. 

**This PR needs a JENKINS_AUTH token to be set as secrets on the repository to work, given that Jenkins in now behind GH Authentication**

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, the user will now have a stable url to pull nightlies binary archives from. E.g.  https://github.com/claraberendsen/ros2/releases/tag/release-rolling-nightlies.
To get the latest update date, it's possible to curl the headers of those artifacts for the last-updated date.
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
Parts of the scripts of the GH Action were boiler-plated with Gemini 3 Pro. They are specified on the commits as per the latest policy in the use of Generative AI: 400a6fc4e16ce2b9d7e7e43dc7a8c8f57140be39, c726a07f19256ba8b6e39ebbe854ecc602464579. 
### Additional Information

This was tested in a fork of this repository.[ The diff between this PR and the fork]( https://github.com/ros2/ros2/compare/b3fac7065c5edc7b5cc83db0ba604574dbee74d5..38951c299defe0fd2fe5eb2fdb6c3aa34e2e4268).

This is what a release with this action looks like: https://github.com/claraberendsen/ros2/releases/tag/release-rolling-nightlies

Below some examples of different logical flows this scripts uses:

- First run that created the archive: https://github.com/claraberendsen/ros2/actions/runs/20972685640/job/60279810612. 
- Failure of action if a job has failed: https://github.com/claraberendsen/ros2/actions/runs/20982333565/job/60309790915 
- Failure if a job has not completed: https://github.com/claraberendsen/ros2/actions/runs/20987013272/job/60323184868
- Successful run once all the set has completed: https://github.com/claraberendsen/ros2/actions/runs/20990292415
- Early exit if artifacts are fresh:https://github.com/claraberendsen/ros2/actions/runs/20991942504/job/60339356918
