### PR TITLE
Added rosidl_rust repository (Humble)

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -191,6 +191,10 @@ repositories:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
     version: humble
+  ros2-rust/rosidl_rust:
+    type: git
+    url: https://github.com/ros2-rust/rosidl_rust.git
+    version: main
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git


### PR DESCRIPTION
This PR is a backport of https://github.com/ros2/ros2/pull/1674 for Humble