### PR TITLE
Jazzy release versions for patch release 7

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -2,23 +2,23 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.5.4
+    version: 2.5.5
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: 1.8.1
+    version: 1.8.2
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.17.3
+    version: 0.17.4
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.16.4
+    version: 0.16.5
   ament/google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
-    version: 0.5.0
+    version: 0.5.1
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
@@ -74,11 +74,11 @@ repositories:
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
-    version: 2.7.1
+    version: 2.7.2
   ros-perception/point_cloud_transport:
     type: git
     url: https://github.com/ros-perception/point_cloud_transport.git
-    version: 4.0.4
+    version: 4.0.7
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
@@ -86,7 +86,7 @@ repositories:
   ros-tooling/keyboard_handler:
     type: git
     url: https://github.com/ros-tooling/keyboard_handler.git
-    version: 0.3.1
+    version: 0.3.2
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
@@ -94,11 +94,11 @@ repositories:
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
-    version: 2.5.4
+    version: 2.5.5
   ros-visualization/python_qt_binding:
     type: git
     url: https://github.com/ros-visualization/python_qt_binding.git
-    version: 2.2.1
+    version: 2.2.2
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
@@ -106,63 +106,63 @@ repositories:
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
-    version: 1.6.0
+    version: 1.6.3
   ros-visualization/rqt_action:
     type: git
     url: https://github.com/ros-visualization/rqt_action.git
-    version: 2.2.0
+    version: 2.2.1
   ros-visualization/rqt_bag:
     type: git
     url: https://github.com/ros-visualization/rqt_bag.git
-    version: 1.5.5
+    version: 1.5.6
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: 2.2.1
+    version: 2.2.2
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: 1.5.5
+    version: 1.5.6
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git
-    version: 1.5.1
+    version: 1.5.2
   ros-visualization/rqt_plot:
     type: git
     url: https://github.com/ros-visualization/rqt_plot.git
-    version: 1.4.4
+    version: 1.4.5
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
-    version: 1.7.2
+    version: 1.7.3
   ros-visualization/rqt_py_console:
     type: git
     url: https://github.com/ros-visualization/rqt_py_console.git
-    version: 1.2.2
+    version: 1.2.3
   ros-visualization/rqt_reconfigure:
     type: git
     url: https://github.com/ros-visualization/rqt_reconfigure.git
-    version: 1.6.2
+    version: 1.6.3
   ros-visualization/rqt_service_caller:
     type: git
     url: https://github.com/ros-visualization/rqt_service_caller.git
-    version: 1.2.1
+    version: 1.2.2
   ros-visualization/rqt_shell:
     type: git
     url: https://github.com/ros-visualization/rqt_shell.git
-    version: 1.2.2
+    version: 1.2.3
   ros-visualization/rqt_srv:
     type: git
     url: https://github.com/ros-visualization/rqt_srv.git
-    version: 1.2.2
+    version: 1.2.3
   ros-visualization/rqt_topic:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
-    version: 1.7.3
+    version: 1.7.5
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: 0.3.0
+    version: 0.3.1
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
@@ -174,7 +174,7 @@ repositories:
   ros/pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: 5.4.2
+    version: 5.4.4
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
@@ -214,7 +214,7 @@ repositories:
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: 0.33.6
+    version: 0.33.9
   ros2/eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
@@ -226,19 +226,19 @@ repositories:
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: 0.19.6
+    version: 0.19.7
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.36.14
+    version: 0.36.19
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 3.4.6
+    version: 3.4.10
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.26.8
+    version: 0.26.11
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -246,7 +246,7 @@ repositories:
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: 4.11.7
+    version: 4.11.10
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
@@ -270,7 +270,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 9.2.7
+    version: 9.2.9
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -282,19 +282,19 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 28.1.11
+    version: 28.1.16
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 7.1.5
+    version: 7.1.9
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 2.11.2
+    version: 2.11.3
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: 6.7.3
+    version: 6.7.5
   ros2/realtime_support:
     type: git
     url: https://github.com/ros2/realtime_support.git
@@ -302,11 +302,11 @@ repositories:
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: 7.3.2
+    version: 7.3.3
   ros2/rmw_connextdds:
     type: git
     url: https://github.com/ros2/rmw_connextdds.git
-    version: 0.22.1
+    version: 0.22.3
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
@@ -314,7 +314,7 @@ repositories:
   ros2/rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
-    version: 3.1.0
+    version: 3.1.1
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
@@ -326,15 +326,15 @@ repositories:
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: 8.2.4
+    version: 8.2.5
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.32.5
+    version: 0.32.8
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
-    version: 0.3.0
+    version: 0.3.1
   ros2/ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git
@@ -346,7 +346,7 @@ repositories:
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 4.6.6
+    version: 4.6.7
   ros2/rosidl_core:
     type: git
     url: https://github.com/ros2/rosidl_core.git
@@ -370,7 +370,7 @@ repositories:
   ros2/rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: 0.22.1
+    version: 0.22.2
   ros2/rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
@@ -382,15 +382,15 @@ repositories:
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: 3.6.2
+    version: 3.6.3
   ros2/rpyutils:
     type: git
     url: https://github.com/ros2/rpyutils.git
-    version: 0.4.1
+    version: 0.4.2
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 14.1.13
+    version: 14.1.19
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -398,11 +398,11 @@ repositories:
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: 0.13.4
+    version: 0.13.5
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git
-    version: 0.20.3
+    version: 0.20.4
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
@@ -410,7 +410,7 @@ repositories:
   ros2/tinyxml2_vendor:
     type: git
     url: https://github.com/ros2/tinyxml2_vendor.git
-    version: 0.9.1
+    version: 0.9.2
   ros2/tlsf:
     type: git
     url: https://github.com/ros2/tlsf.git


### PR DESCRIPTION
## Description
Jazzy patch release: https://discourse.openrobotics.org/t/preparing-for-jazzy-sync-and-patch-release-2026-01-22/

* Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=27218)](http://ci.ros2.org/job/ci_linux/27218/)
*  Linux-aarch64: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=20561)](http://ci.ros2.org/job/ci_linux-aarch64/20561/)
*  Linux-rhel: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=6996)](http://ci.ros2.org/job/ci_linux-rhel/6996/)
*  Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=26513)](http://ci.ros2.org/job/ci_windows/26513/)
