### PR TITLE
MSVC 2022 transition

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -75,7 +75,7 @@ mypy = "==1.9.0"
 mypy_extensions = "==1.0.0"
 nlohmann_json = "==3.11.3"
 numpy = "==1.26.4"
-opencv = "==4.12.0"  # TODO: Conda has 4.6.0, but it is not installable with Python 3.12
+opencv = "==4.10.0"  # TODO: Conda has 4.6.0, but it is not installable with Python 3.12
 openssl = "==3.3.2"  # TODO: Conda has 3.0.13, but it is not installable with Python 3.12
 orocos-kdl = "==1.5.1"
 osrf_pycommon = "==0.2.1"


### PR DESCRIPTION
## Description
This PR has the needed changes to `pixi.toml` to move Rolling over to use MSVC2022 compiler. 

### Is this user-facing behavior change?

Yes, the default option on CI will become MSVC2022.
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Should solve https://github.com/ros2/ros2/issues/1719 for Rolling and upcoming releases. 