### PR TITLE
Add ogre dependency version 1.12.10

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -75,6 +75,7 @@ mypy = "==1.9.0"
 mypy_extensions = "==1.0.0"
 nlohmann_json = "==3.11.3"
 numpy = "==1.26.4"
+ogre = "==1.12.10"
 opencv = "==4.9.0"  # TODO: Conda has 4.6.0, but it is not installable with Python 3.12
 openssl = "==3.3.2"  # TODO: Conda has 3.0.13, but it is not installable with Python 3.12
 orocos-kdl = "==1.5.1"


### PR DESCRIPTION
Part of https://github.com/ros2/rviz/pull/1683

Lowering priority since we worked around issues in rviz_ogre_vendor https://github.com/ros2/rviz/pull/1684

## Description

This adds ogre to `pixi.toml` instead of expecting `rviz_ogre_vendor

### Is this user-facing behavior change?


### Did you use Generative AI?

no

### Additional Information

https://anaconda.org/channels/conda-forge/packages/ogre/overview