### PR TITLE
Kilted: Pinned FastCDR version

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -30,7 +30,7 @@ repositories:
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: 2.3.x
+    version: 2.3.5
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
Kilted: Pinned FastCDR version. 

This change https://github.com/eProsima/Fast-CDR/pull/303 only make sense on Rolling not Kilted