### PR TITLE
Add all release versions for lyrical repos

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -398,7 +398,7 @@ repositories:
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git
-    version: cc976b51fe8c82b368cdb0b99d5467c2c3be6217
+    version: 0.25.3
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -2,420 +2,421 @@ repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: lyrical
+    version: 2.8.7
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: lyrical
+    version: 1.13.3
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: lyrical
+    version: 0.20.5
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: lyrical
+    version: 0.18.3
   ament/google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
-    version: lyrical
+    version: 0.7.0
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: lyrical
+    version: 1.16.1
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: lyrical
+    version: 3.2.0
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: 2.3.x
+    version: v2.3.5
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: 3.6.x
+    version: v3.6.1
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: master
+    version: v1.4.1
   eclipse-cyclonedds/cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: releases/11.0.x
+    version: 11.0.1
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
-    version: release_2.0
+    version: v2.0.6
   gazebo-release/gz_cmake_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_cmake_vendor.git
-    version: rolling
+    version: 0.4.4
   gazebo-release/gz_math_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_math_vendor.git
-    version: rolling
+    version: 0.4.3
   gazebo-release/gz_utils_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_utils_vendor.git
-    version: rolling
+    version: 0.4.1
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: rolling
+    version: 2.3.0
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: lyrical
+    version: 6.4.7
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
-    version: lyrical
+    version: 2.11.3
   ros-perception/point_cloud_transport:
     type: git
     url: https://github.com/ros-perception/point_cloud_transport.git
-    version: lyrical
+    version: 5.4.0
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
-    version: rolling
+    version: 2.6.0
   ros-tooling/keyboard_handler:
     type: git
     url: https://github.com/ros-tooling/keyboard_handler.git
-    version: rolling
+    version: 0.5.0
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: rolling
+    version: 2.1.1
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
-    version: lyrical
+    version: 2.8.3
   ros-visualization/python_qt_binding:
     type: git
     url: https://github.com/ros-visualization/python_qt_binding.git
-    version: lyrical
+    version: 2.5.4
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: lyrical
+    version: 2.10.7
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
-    version: lyrical
+    version: 1.10.4
   ros-visualization/rqt_action:
     type: git
     url: https://github.com/ros-visualization/rqt_action.git
-    version: lyrical
+    version: 2.4.1
   ros-visualization/rqt_bag:
     type: git
     url: https://github.com/ros-visualization/rqt_bag.git
-    version: lyrical
+    version: 2.2.2
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
-    version: lyrical
+    version: 2.4.3
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: lyrical
+    version: 1.8.2
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git
-    version: lyrical
+    version: 1.7.2
   ros-visualization/rqt_plot:
     type: git
     url: https://github.com/ros-visualization/rqt_plot.git
-    version: lyrical
+    version: 1.7.5
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
-    version: lyrical
+    version: 1.10.2
   ros-visualization/rqt_py_console:
     type: git
     url: https://github.com/ros-visualization/rqt_py_console.git
-    version: lyrical
+    version: 1.5.2
   ros-visualization/rqt_reconfigure:
     type: git
     url: https://github.com/ros-visualization/rqt_reconfigure.git
-    version: lyrical
+    version: 1.8.4
   ros-visualization/rqt_service_caller:
     type: git
     url: https://github.com/ros-visualization/rqt_service_caller.git
-    version: lyrical
+    version: 1.5.2
   ros-visualization/rqt_shell:
     type: git
     url: https://github.com/ros-visualization/rqt_shell.git
-    version: lyrical
+    version: 1.4.1
   ros-visualization/rqt_srv:
     type: git
     url: https://github.com/ros-visualization/rqt_srv.git
-    version: lyrical
+    version: 1.4.1
   ros-visualization/rqt_topic:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
-    version: lyrical
+    version: 2.1.0
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
-    version: lyrical
+    version: 0.5.1
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
-    version: lyrical
+    version: 2.9.4
   ros/kdl_parser:
     type: git
     url: https://github.com/ros/kdl_parser.git
-    version: lyrical
+    version: 3.0.1
   ros/pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: lyrical
+    version: 5.8.4
   ros/resource_retriever:
     type: git
     url: https://github.com/ros/resource_retriever.git
-    version: lyrical
+    version: 3.9.3
   ros/robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
-    version: lyrical
+    version: 3.5.5
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: lyrical
+    version: 4.5.1
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: lyrical
+    version: 1.10.8
   ros/urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
-    version: rolling
+    version: 6.0.0
   ros/urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
-    version: rolling
+    version: 3.0.0
   ros2-rust/rosidl_rust:
     type: git
     url: https://github.com/ros2-rust/rosidl_rust.git
-    version: main
+    version: 0.4.12
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: lyrical
+    version: 0.15.7
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: lyrical
+    version: 5.9.2
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
-    version: lyrical
+    version: 1.9.1
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: lyrical
+    version: 0.37.8
   ros2/eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
-    version: lyrical
+    version: 0.5.1
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: lyrical
+    version: 0.14.1
   ros2/examples:
     type: git
     url: https://github.com/ros2/examples.git
-    version: lyrical
+    version: 0.21.5
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: lyrical
+    version: 0.45.7
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: lyrical
+    version: 3.9.7
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: lyrical
+    version: 0.29.7
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: lyrical
+    version: 1.8.1
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: lyrical
+    version: 7.3.8
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
-    version: lyrical
+    version: 0.9.0
   ros2/performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
-    version: lyrical
+    version: 0.4.1
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: lyrical
+    version: 10.4.3
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: lyrical
+    version: 2.4.4
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: lyrical
+    version: 3.4.1
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: lyrical
+    version: 31.0.3
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: lyrical
+    version: 10.0.9
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: lyrical
+    version: 2.14.4
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: lyrical
+    version: 7.1.1
   ros2/realtime_support:
     type: git
     url: https://github.com/ros2/realtime_support.git
-    version: lyrical
+    version: 0.20.0
   ros2/resource_retriever_service:
     type: git
     url: https://github.com/ros2/resource_retriever_service.git
-    version: lyrical
+    version: 0.0.1
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: lyrical
+    version: 7.10.1
   ros2/rmw_connextdds:
     type: git
     url: https://github.com/ros2/rmw_connextdds.git
-    version: lyrical
+    version: 1.2.5
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: lyrical
+    version: 4.1.4
   ros2/rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
-    version: lyrical
+    version: 6.0.0
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: lyrical
+    version: 9.4.7
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: lyrical
+    version: 3.1.5
   ros2/rmw_zenoh:
     type: git
     url: https://github.com/ros2/rmw_zenoh.git
-    version: lyrical
+    version: 0.10.3
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: lyrical
+    version: 8.10.1
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: lyrical
+    version: 0.40.6
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
-    version: lyrical
+    version: 0.5.2
   ros2/ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git
-    version: lyrical
+    version: 0.9.1
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: lyrical
+    version: 0.33.1
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: lyrical
+    version: 5.2.0
   ros2/rosidl_core:
     type: git
     url: https://github.com/ros2/rosidl_core.git
-    version: lyrical
+    version: 0.4.3
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: lyrical
+    version: 0.13.0
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: lyrical
+    version: 1.8.1
   ros2/rosidl_dynamic_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_dynamic_typesupport.git
-    version: lyrical
+    version: 0.4.1
   ros2/rosidl_dynamic_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
-    version: lyrical
+    version: 0.5.1
   ros2/rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: lyrical
+    version: 0.27.2
   ros2/rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
-    version: lyrical
+    version: 0.15.2
   ros2/rosidl_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_typesupport.git
-    version: lyrical
+    version: 3.4.2
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: lyrical
+    version: 3.9.5
   ros2/rpyutils:
     type: git
     url: https://github.com/ros2/rpyutils.git
-    version: lyrical
+    version: 0.7.2
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: lyrical
+    version: 15.2.2
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
-    version: lyrical
+    version: 1.8.0
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: lyrical
-  ros2/system_tests:
-    type: git
-    url: https://github.com/ros2/system_tests.git
-    version: lyrical
+    version: 0.16.4
+#  ros2/system_tests:
+#    type: git
+#    url: https://github.com/ros2/system_tests.git
+#    version: cc976b51fe8c82b368cdb0b99d5467c2c3be6217
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
-    version: lyrical
+    version: 0.14.1
   ros2/tlsf:
     type: git
     url: https://github.com/ros2/tlsf.git
-    version: lyrical
+    version: 0.11.1
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: lyrical
+    version: 2.8.1
   ros2/urdf:
     type: git
     url: https://github.com/ros2/urdf.git
-    version: lyrical
+    version: 2.13.2
   ros2/yaml_cpp_vendor:
     type: git
     url: https://github.com/ros2/yaml_cpp_vendor.git
-    version: lyrical
+    version: 9.2.1
+

--- a/ros2.repos
+++ b/ros2.repos
@@ -395,10 +395,10 @@ repositories:
     type: git
     url: https://github.com/ros2/sros2.git
     version: 0.16.4
-  #ros2/system_tests:
-  #  type: git
-  #  url: https://github.com/ros2/system_tests.git
-  #  version: cc976b51fe8c82b368cdb0b99d5467c2c3be6217
+  ros2/system_tests:
+    type: git
+    url: https://github.com/ros2/system_tests.git
+    version: cc976b51fe8c82b368cdb0b99d5467c2c3be6217
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -395,10 +395,10 @@ repositories:
     type: git
     url: https://github.com/ros2/sros2.git
     version: 0.16.4
-#  ros2/system_tests:
-#    type: git
-#    url: https://github.com/ros2/system_tests.git
-#    version: cc976b51fe8c82b368cdb0b99d5467c2c3be6217
+  #ros2/system_tests:
+  #  type: git
+  #  url: https://github.com/ros2/system_tests.git
+  #  version: cc976b51fe8c82b368cdb0b99d5467c2c3be6217
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
@@ -419,4 +419,3 @@ repositories:
     type: git
     url: https://github.com/ros2/yaml_cpp_vendor.git
     version: 9.2.1
-


### PR DESCRIPTION
Update lyrical-release with the current latest releases for the Lyrical beta. Once this merges I'll create a `release-lyrical-beta-20260429` tag. I commented out `system_tests` since I don't think it gets released.

I made this with `vcs export --exact-with-tag` followed by hand edits to specify versions for repos that for some reason got a hash in the file instead of a tag.