### PR TITLE
Use vcs2l when validating repos files

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Clone project
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: python3 -m pip install vcstool yamllint
+        run: python3 -m pip install vcs2l yamllint
       - name: Validate formatting
         run: >
           yamllint ros2.repos


### PR DESCRIPTION
The old `vcstool` has a bug that causes `validate` to fail for SHA refs. The bug appears to be fixed in `vcs2l`, so I think it's time to move forward.