### PR TITLE
Update lyrical-release with today's releases

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -1,7 +1,7 @@
 # ROS Lyrical release distribution file
-# Generated on 2026-04-30 22:34:54
+# Generated on 2026-04-30 22:39:21
 # --pin eclipse-iceoryx/iceoryx=41b69258cf486685f23bd9cc256888aad99b9d9e
-# WARNING: Did not find a release for: ros2/system_tests in lyrical
+# --pin ros2/system_tests=cc976b51fe8c82b368cdb0b99d5467c2c3be6217
 repositories:
   ament/ament_cmake:
     type: git
@@ -399,6 +399,10 @@ repositories:
     type: git
     url: https://github.com/ros2/sros2.git
     version: 0.16.5
+  ros2/system_tests:
+    type: git
+    url: https://github.com/ros2/system_tests.git
+    version: cc976b51fe8c82b368cdb0b99d5467c2c3be6217
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -1,7 +1,7 @@
 # ROS Lyrical release distribution file
-# Generated on 2026-04-30 22:27:29
+# Generated on 2026-04-30 22:34:54
 # --pin eclipse-iceoryx/iceoryx=41b69258cf486685f23bd9cc256888aad99b9d9e
-# WARNING: Did not find a release for: https://github.com/ros2/system_tests.git in lyrical
+# WARNING: Did not find a release for: ros2/system_tests in lyrical
 repositories:
   ament/ament_cmake:
     type: git

--- a/ros2.repos
+++ b/ros2.repos
@@ -1,3 +1,7 @@
+# ROS Lyrical release distribution file
+# Generated on 2026-04-30 22:27:29
+# --pin eclipse-iceoryx/iceoryx=41b69258cf486685f23bd9cc256888aad99b9d9e
+# WARNING: Did not find a release for: https://github.com/ros2/system_tests.git in lyrical
 repositories:
   ament/ament_cmake:
     type: git
@@ -46,7 +50,7 @@ repositories:
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
-    version: v2.0.6
+    version: 41b69258cf486685f23bd9cc256888aad99b9d9e
   gazebo-release/gz_cmake_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_cmake_vendor.git
@@ -62,11 +66,11 @@ repositories:
   osrf/osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: 2.3.0
+    version: 2.3.1
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
-    version: 6.4.7
+    version: 6.4.8
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git
@@ -74,23 +78,23 @@ repositories:
   ros-perception/point_cloud_transport:
     type: git
     url: https://github.com/ros-perception/point_cloud_transport.git
-    version: 5.4.0
+    version: 5.4.1
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
-    version: 2.6.0
+    version: 2.6.1
   ros-tooling/keyboard_handler:
     type: git
     url: https://github.com/ros-tooling/keyboard_handler.git
-    version: 0.5.0
+    version: 0.5.1
   ros-tooling/libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: 2.1.1
+    version: 2.1.2
   ros-visualization/interactive_markers:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
-    version: 2.8.3
+    version: 2.8.4
   ros-visualization/python_qt_binding:
     type: git
     url: https://github.com/ros-visualization/python_qt_binding.git
@@ -202,7 +206,7 @@ repositories:
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: 0.15.7
+    version: 0.15.8
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
@@ -238,7 +242,7 @@ repositories:
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.29.7
+    version: 0.29.8
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -246,7 +250,7 @@ repositories:
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: 7.3.8
+    version: 7.3.9
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
@@ -258,7 +262,7 @@ repositories:
   ros2/rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 10.4.3
+    version: 10.4.4
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -270,15 +274,15 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 31.0.3
+    version: 32.0.0
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 10.0.9
+    version: 10.0.10
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 2.14.4
+    version: 2.14.5
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
@@ -290,7 +294,7 @@ repositories:
   ros2/resource_retriever_service:
     type: git
     url: https://github.com/ros2/resource_retriever_service.git
-    version: 0.0.1
+    version: 0.0.2
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
@@ -298,7 +302,7 @@ repositories:
   ros2/rmw_connextdds:
     type: git
     url: https://github.com/ros2/rmw_connextdds.git
-    version: 1.2.5
+    version: 1.2.6
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
@@ -322,11 +326,11 @@ repositories:
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: 8.10.1
+    version: 8.10.2
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.40.6
+    version: 0.40.7
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -338,7 +342,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.33.1
+    version: 0.33.2
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -394,11 +398,7 @@ repositories:
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: 0.16.4
-  ros2/system_tests:
-    type: git
-    url: https://github.com/ros2/system_tests.git
-    version: 0.25.3
+    version: 0.16.5
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -1,5 +1,5 @@
-# ROS Lyrical release distribution file
-# Generated on 2026-04-30 22:39:21
+# ROS Lyrical repos file
+# Generated on 2026-04-30 22:41:43
 # --pin eclipse-iceoryx/iceoryx=41b69258cf486685f23bd9cc256888aad99b9d9e
 # --pin ros2/system_tests=cc976b51fe8c82b368cdb0b99d5467c2c3be6217
 repositories:


### PR DESCRIPTION
## Description

This PR updates `lyrical-release` with today's bloom-release's. The iceoryx fix is important for Windows, but it might be a while before they release, so I pinned to the latest commit on the release_2.0 branch: https://github.com/eclipse-iceoryx/iceoryx/tree/release_2.0

`ros2/system_tests` doesn't get bloom-release'd, so I pinned it to the latest commit on the `lyrical` branch.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

I used gemini to iterate on a script to generate this file: https://github.com/sloretz/scripts-and-stuff/blob/master/sync_helpers/make_release_repos.py

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
