### PR TITLE
Fix pixi.toml workspace name for Lyrical release

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,5 @@
 [workspace]
-name = "pixi_ros2_rolling"
+name = "pixi_ros2_lyrical"
 version = "0.1.0"
 description = "Dependencies to build ROS 2 on Windows and Linux"
 authors = ["Chris Lalancette <clalancette@gmail.com>"]


### PR DESCRIPTION
## Description

Fix the incorrect pixi.toml workspace name in ROS 2 Lyrical beta release. The workspace name was set to "pixi_ros2_rolling" instead of "pixi_ros2_lyrical", causing confusion for users who download the Lyrical binary release (release-lyrical-beta-20260430) and see "(pixi_ros2_rolling)" when running `pixi shell`.

**Key changes:**
- Updated `pixi.toml` workspace name from `"pixi_ros2_rolling"` to `"pixi_ros2_lyrical"` to match the Lyrical release version

**Impact:**
- Functionally, ROS 2 works correctly; this is a configuration/release preparation issue
- Users will no longer see confusing "rolling" environment name when installing Lyrical

### Is this user-facing behavior change?

Yes, users will see `(pixi_ros2_lyrical)` in their environment name instead of `(pixi_ros2_rolling)` when running `pixi shell` after installing ROS 2 Lyrical beta. This matches the release version they downloaded and prevents confusion.

### Did you use Generative AI?
No.

### Additional Information
- **Release tag:** `release-lyrical-beta-20260430`
- **Binary package:** `ros2-lyrical-2026-04-30-windows-AMD64.zip`
- **Installation guide:** https://docs.ros.org/en/lyrical/Installation/Windows-Install-Binary.html
- Found while installing ROS 2 Lyrical on Windows 11 (Binary) with pixi
