### PR TITLE
Updated QT_QPA_PLATFORM_PLUGIN_PATH for qt6

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ pyqt6 = ">=6.7,<7"
 pyqt6-sip = ">=13.0,<14"
 
 [target.win-64.activation.env]
-QT_QPA_PLATFORM_PLUGIN_PATH="%cd%\\.pixi\\envs\\default\\Library\\plugins\\platforms"
+QT_QPA_PLATFORM_PLUGIN_PATH="%cd%\\.pixi\\envs\\default\\Library\\lib\\qt6\\plugins\\platforms"
 
 [target.linux-64.dependencies]
 binutils_linux-64 = "==2.44"


### PR DESCRIPTION
## Description

### Part of Lyrical Luth Testing Party Fixes
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
The QT_QPA_PLATFORM_PLUGIN_PATH configured in the Windows Pixi environment(`pixi.toml`) points to a directory that no longer exists in ROS 2 Lyrical.


In previous distributions (e.g., Jazzy and Humble), the following path resolved correctly:
```bash
QT_QPA_PLATFORM_PLUGIN_PATH="%cd%\\.pixi\\envs\\default\\Library\\plugins\\platforms"
``` 
In Lyrical, this directory is not present. As a result, Qt-based applications(turtlesim) fail to locate the required platform plugin (`qwindows.dll`).

### Proposed Fix

#### Option 1 (Qt installation path) <- Current change
Points directly to the Qt6 plugin directory in the Pixi environment:
```bash
QT_QPA_PLATFORM_PLUGIN_PATH="%cd%\\.pixi\\envs\\default\\Library\\lib\\qt6\\plugins\\platforms"
```
This works with the current Qt6 layout. However, it depends on the directory structure (`lib/qt6`), which may change in the future versions.

#### Option 2 (install-space path)
This option uses the plugin directory in the ROS install space:
```bash
QT_QPA_PLATFORM_PLUGIN_PATH="%cd%\\bin\\platforms"
```
`qwindows.dll` is also present in Jazzy (not in Humble) at this location. If this is the intended convention, this option may be preferred.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes ros2/lyrical_tutorial_party#2618

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, currently applications fail with:
```bash
(pixi_ros2_rolling) C:\dev\lyrical>ros2 run turtlesim turtlesim_node
qt.qpa.plugin: Could not find the Qt platform plugin "windows" in "C:\dev\lyrical\.pixi\envs\default\Library\plugins\platforms"
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```
This fix will restore expected behavior.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
- RViz2 includes a local copy of the plugin under:
    ```bash
    Lib\rviz2\platforms
    ```