### PR TITLE
Update Lyrical Release versions

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -1,7 +1,7 @@
 # ROS Lyrical repos file
-# Generated on 2026-04-30 22:41:43
+# Generated on 2026-05-21 01:20:14
 # --pin eclipse-iceoryx/iceoryx=41b69258cf486685f23bd9cc256888aad99b9d9e
-# --pin ros2/system_tests=cc976b51fe8c82b368cdb0b99d5467c2c3be6217
+# --pin ros2/system_tests=5a5f8d5a908675b44aeedda5a252b54fa2a6e7a2
 repositories:
   ament/ament_cmake:
     type: git
@@ -14,7 +14,7 @@ repositories:
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.20.5
+    version: 0.20.6
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
@@ -102,19 +102,19 @@ repositories:
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
-    version: 2.10.7
+    version: 2.11.0
   ros-visualization/rqt:
     type: git
     url: https://github.com/ros-visualization/rqt.git
-    version: 1.10.4
+    version: 1.10.5
   ros-visualization/rqt_action:
     type: git
     url: https://github.com/ros-visualization/rqt_action.git
-    version: 2.4.1
+    version: 2.5.0
   ros-visualization/rqt_bag:
     type: git
     url: https://github.com/ros-visualization/rqt_bag.git
-    version: 2.2.2
+    version: 2.2.3
   ros-visualization/rqt_console:
     type: git
     url: https://github.com/ros-visualization/rqt_console.git
@@ -122,7 +122,7 @@ repositories:
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: 1.8.2
+    version: 1.8.3
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git
@@ -134,7 +134,7 @@ repositories:
   ros-visualization/rqt_publisher:
     type: git
     url: https://github.com/ros-visualization/rqt_publisher.git
-    version: 1.10.2
+    version: 1.10.3
   ros-visualization/rqt_py_console:
     type: git
     url: https://github.com/ros-visualization/rqt_py_console.git
@@ -158,7 +158,7 @@ repositories:
   ros-visualization/rqt_topic:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
-    version: 2.1.0
+    version: 2.1.1
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
@@ -190,7 +190,7 @@ repositories:
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: 1.10.8
+    version: 1.10.9
   ros/urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
@@ -250,7 +250,7 @@ repositories:
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: 7.3.9
+    version: 7.4.1
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
@@ -266,7 +266,7 @@ repositories:
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: 2.4.4
+    version: 2.4.5
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
@@ -290,7 +290,7 @@ repositories:
   ros2/realtime_support:
     type: git
     url: https://github.com/ros2/realtime_support.git
-    version: 0.20.0
+    version: 0.20.1
   ros2/resource_retriever_service:
     type: git
     url: https://github.com/ros2/resource_retriever_service.git
@@ -302,7 +302,7 @@ repositories:
   ros2/rmw_connextdds:
     type: git
     url: https://github.com/ros2/rmw_connextdds.git
-    version: 1.2.6
+    version: 1.2.7
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
@@ -314,7 +314,7 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 9.4.7
+    version: 9.4.8
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
@@ -342,7 +342,7 @@ repositories:
   ros2/rosbag2:
     type: git
     url: https://github.com/ros2/rosbag2.git
-    version: 0.33.2
+    version: 0.33.3
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -390,7 +390,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 15.2.2
+    version: 15.2.3
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -398,11 +398,11 @@ repositories:
   ros2/sros2:
     type: git
     url: https://github.com/ros2/sros2.git
-    version: 0.16.5
+    version: 0.16.6
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git
-    version: cc976b51fe8c82b368cdb0b99d5467c2c3be6217
+    version: 5a5f8d5a908675b44aeedda5a252b54fa2a6e7a2
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git


### PR DESCRIPTION
## Description

This updates the `lyrical-release` branch with the current ROS Lyrical versions. I don't anticipate any changes to this before the release.

### Is this user-facing behavior change?
I guess?

### Did you use Generative AI?

No

### Additional Information

I used https://github.com/sloretz/scripts-and-stuff/blob/c91f2d92c8bbb9cbd3fc1cbb402e1dff2ef86cd6/sync_helpers/make_release_repos.py

```
curl https://raw.githubusercontent.com/ros2/ros2/refs/heads/lyrical/ros2.repos -o /tmp/lyrical.repos
python3 make_release_repos.py --rosdistro lyrical --input-repos /tmp/lyrical.repos --pin eclipse-iceoryx/iceoryx=41b69258cf486685f23bd9cc256888aad99b9d9e --pin ros2/system_tests=5a5f8d5a908675b44aeedda5a252b54fa2a6e7a2 > lyrical-release.repos
```