### PR TITLE
Update lyrical ros2.repos for 2026-08-07 sync

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -1,12 +1,12 @@
 # ROS Lyrical repos file
-# Generated on 2026-06-23 03:21:52
+# Generated on 2026-08-06 23:22:45
 # --pin eclipse-iceoryx/iceoryx=35311bfe5338392d65b18f148de70b803f6fc48e
-# --pin ros2/system_tests=5a5f8d5a908675b44aeedda5a252b54fa2a6e7a2
+# --pin ros2/system_tests=37210e8b7e47be6280a9a7927877d32354036ddf
 repositories:
   ament/ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.8.7
+    version: 2.8.8
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
@@ -38,7 +38,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v3.6.1
+    version: v3.6.2
   eProsima/foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -58,7 +58,7 @@ repositories:
   gazebo-release/gz_math_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_math_vendor.git
-    version: 0.4.3
+    version: 0.4.4
   gazebo-release/gz_utils_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_utils_vendor.git
@@ -78,7 +78,7 @@ repositories:
   ros-perception/point_cloud_transport:
     type: git
     url: https://github.com/ros-perception/point_cloud_transport.git
-    version: 5.4.2
+    version: 5.4.3
   ros-planning/navigation_msgs:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
@@ -98,7 +98,7 @@ repositories:
   ros-visualization/python_qt_binding:
     type: git
     url: https://github.com/ros-visualization/python_qt_binding.git
-    version: 2.5.4
+    version: 2.5.5
   ros-visualization/qt_gui_core:
     type: git
     url: https://github.com/ros-visualization/qt_gui_core.git
@@ -122,11 +122,11 @@ repositories:
   ros-visualization/rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
-    version: 1.8.4
+    version: 1.8.5
   ros-visualization/rqt_msg:
     type: git
     url: https://github.com/ros-visualization/rqt_msg.git
-    version: 1.7.3
+    version: 1.7.4
   ros-visualization/rqt_plot:
     type: git
     url: https://github.com/ros-visualization/rqt_plot.git
@@ -146,7 +146,7 @@ repositories:
   ros-visualization/rqt_service_caller:
     type: git
     url: https://github.com/ros-visualization/rqt_service_caller.git
-    version: 1.5.3
+    version: 1.5.4
   ros-visualization/rqt_shell:
     type: git
     url: https://github.com/ros-visualization/rqt_shell.git
@@ -158,7 +158,7 @@ repositories:
   ros-visualization/rqt_topic:
     type: git
     url: https://github.com/ros-visualization/rqt_topic.git
-    version: 2.1.1
+    version: 2.1.2
   ros-visualization/tango_icons_vendor:
     type: git
     url: https://github.com/ros-visualization/tango_icons_vendor.git
@@ -210,7 +210,7 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 5.9.2
+    version: 5.9.3
   ros2/console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
@@ -218,7 +218,7 @@ repositories:
   ros2/demos:
     type: git
     url: https://github.com/ros2/demos.git
-    version: 0.37.8
+    version: 0.37.9
   ros2/eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
@@ -234,15 +234,15 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.45.7
+    version: 0.45.9
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 3.9.7
+    version: 3.9.8
   ros2/launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.29.8
+    version: 0.29.9
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
@@ -250,7 +250,7 @@ repositories:
   ros2/message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: 7.4.1
+    version: 7.4.2
   ros2/mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
@@ -274,7 +274,7 @@ repositories:
   ros2/rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 32.0.0
+    version: 32.0.2
   ros2/rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
@@ -286,7 +286,7 @@ repositories:
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: 7.1.1
+    version: 7.1.2
   ros2/realtime_support:
     type: git
     url: https://github.com/ros2/realtime_support.git
@@ -294,7 +294,7 @@ repositories:
   ros2/resource_retriever_service:
     type: git
     url: https://github.com/ros2/resource_retriever_service.git
-    version: 0.0.2
+    version: 0.0.3
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
@@ -314,15 +314,15 @@ repositories:
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
-    version: 9.4.8
+    version: 9.4.9
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 3.1.5
+    version: 3.1.6
   ros2/rmw_zenoh:
     type: git
     url: https://github.com/ros2/rmw_zenoh.git
-    version: 0.10.4
+    version: 0.10.5
   ros2/ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
@@ -330,7 +330,7 @@ repositories:
   ros2/ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.40.7
+    version: 0.40.8
   ros2/ros2cli_common_extensions:
     type: git
     url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -390,7 +390,7 @@ repositories:
   ros2/rviz:
     type: git
     url: https://github.com/ros2/rviz.git
-    version: 15.2.4
+    version: 15.2.5
   ros2/spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
@@ -402,7 +402,7 @@ repositories:
   ros2/system_tests:
     type: git
     url: https://github.com/ros2/system_tests.git
-    version: 5a5f8d5a908675b44aeedda5a252b54fa2a6e7a2
+    version: 37210e8b7e47be6280a9a7927877d32354036ddf
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git


### PR DESCRIPTION
## Description

This updates the versions in the lyrical release ros2.repos file for tomorrow's sync.

https://discourse.openrobotics.org/t/preparing-for-lyrical-sync-2026-08-07/57195

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

no

### Additional Information

Used script from https://github.com/ros2/pmc_scripts/pull/3

```
rosboss sync update-repos-file --rosdistro lyrical --pin eclipse-iceoryx/iceoryx=35311bfe5338392d65b18f148de70b803f6fc48e --pin ros2/system_tests=37210e8b7e47be6280a9a7927877d32354036ddf --date 2026-08-07
```