### PR TITLE
Pixi: Add colorama dependency

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -68,6 +68,7 @@ catkin_pkg = "==1.0.0"
 cli11 = "==2.4.1"
 clang-format = "==18.1.8"
 cmake = "==3.28.3"
+colorama = "==0.4.6"
 console_bridge = "==1.0.1"
 coverage = "==7.4.4"
 cppcheck = "==2.15.0"  # TODO: This version doesn't actually work, so we should just remove ament_cppcheck


### PR DESCRIPTION
## Description

Fix CI issue for https://github.com/ros2/ros2cli/pull/1248. In that PR, we added color support for ros2cli, `python3-colorama` is used for cross-platform colored terminal output.

### Did you use Generative AI?

No.

### Additional Information

- Related fix PR: https://github.com/ros2/ci/pull/892