### PR TITLE
Declare which pixi this workspace expects

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -5,6 +5,7 @@ description = "Dependencies to build ROS 2 on Windows and Linux"
 authors = ["Chris Lalancette <clalancette@gmail.com>"]
 channels = ["conda-forge"]
 platforms = ["win-64", "linux-64"]
+requires-pixi = ">=0.78"
 
 [target.win-64.dependencies]
 7zip = "==26.00"


### PR DESCRIPTION
A lock file's contents depend on which pixi wrote it. Before shipping one, the workspace should say which pixi it expects, or a contributor on an older release regenerates the lock, gets a legitimately different file, and has no way to tell that the version is the reason.

`>=0.78` is the current release. It is a floor, so it does not stop anyone moving forward.