### PR TITLE
use clang-tools instead of clang-format (backport #1865)

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -66,7 +66,7 @@ benchmark = "==1.8.3"
 bullet = "==3.25"  # TODO: Conda has 3.24, but it is not installable with Python 3.12
 catkin_pkg = "==1.0.0"
 cli11 = "==2.4.1"
-clang-format = "==18.1.8"
+clang-tools = "==18.1.8"
 cmake = "==3.28.3"
 console_bridge = "==1.0.1"
 coverage = "==7.4.4"


### PR DESCRIPTION
## Description

`clang-tidy` is missing in pixi environment. Since `clang-tools` contains both `clang-format` and `clang-tidy`, I suggest to use `clang-tools` instead of `clang-format`

Fixes #1864

### Is this user-facing behavior change?

Yes. Uses can use clang-tidy in pixi environment.

### Did you use Generative AI?

Assisted by CodeX, Luna.

### Additional Information

`clang-tools` installs following packages/tools. The reason I didn't specify `clang-tidy` is that it is missing in conda-forge registry.

- clang-tidy
- clangd
- clang-check
- clang-query
- clang-rename
- clang-repl
- clang-doc
- clang-include-fixer
- clang-include-cleaner
- clang-apply-replacements
- clang-change-namespace
- clang-move
- clang-reorder-fields
- clang-scan-deps
- scan-build
- scan-view
- run-clang-tidy
- intercept-build
- find-all-symbols
- modularize
- diagtool

-----

This is a manual backport of pull request https://github.com/ros2/ros2/pull/1865